### PR TITLE
feat: 예산 도메인 기능 및 비즈니스 로직 구현

### DIFF
--- a/src/main/java/com/stcom/smartmealtable/domain/Budget/Budget.java
+++ b/src/main/java/com/stcom/smartmealtable/domain/Budget/Budget.java
@@ -66,4 +66,8 @@ public abstract class Budget extends BaseTimeEntity {
     public boolean isOverLimit() {
         return spendAmount.compareTo(limit) > 0;
     }
+
+    public void changeLimit(BigDecimal limit) {
+        this.limit = limit;
+    }
 }

--- a/src/main/java/com/stcom/smartmealtable/domain/Budget/Budget.java
+++ b/src/main/java/com/stcom/smartmealtable/domain/Budget/Budget.java
@@ -68,6 +68,9 @@ public abstract class Budget extends BaseTimeEntity {
     }
 
     public void changeLimit(BigDecimal limit) {
+        if (limit == null || limit.signum() < 0) {
+            throw new IllegalArgumentException("예산 한도는 0 이상이어야 합니다.");
+        }
         this.limit = limit;
     }
 }

--- a/src/main/java/com/stcom/smartmealtable/repository/BudgetRepository.java
+++ b/src/main/java/com/stcom/smartmealtable/repository/BudgetRepository.java
@@ -44,7 +44,7 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     @Query("select b from Budget b where type(b) = MonthlyBudget and b.memberProfile.id = :profileId and treat(b as MonthlyBudget).yearMonth = :yearMonth")
     Optional<MonthlyBudget> findMonthlyBudgetByMemberProfileIdAndYearMonth(Long profileId, YearMonth yearMonth);
 
-    @Query("select b from Budget b where type(b) = DailyBudget and b.memberProfile.id = :profileId and treat(b as DailyBudget).date between :startOfWeek and :endOfWeek")
+    @Query("select b from Budget b where type(b) = DailyBudget and b.memberProfile.id = :profileId and treat(b as DailyBudget).date between :startOfWeek and :endOfWeek order by treat(b as DailyBudget).date asc")
     List<DailyBudget> findDailyBudgetsByMemberProfileIdAndDateBetween(Long profileId, LocalDate startOfWeek,
                                                                       LocalDate endOfWeek);
 }

--- a/src/main/java/com/stcom/smartmealtable/repository/BudgetRepository.java
+++ b/src/main/java/com/stcom/smartmealtable/repository/BudgetRepository.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,13 +18,23 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     List<DailyBudget> findDailyBudgetsViaType(@Param("memberProfileId") Long memberProfileId);
 
     @Query("select b from Budget b where type(b) = DailyBudget and b.memberProfile.id = :memberProfileId order by treat(b as DailyBudget).date desc")
-    Optional<DailyBudget> findFirstDailyBudgetByMemberProfileId(@Param("memberProfileId") Long memberProfileId);
+    List<DailyBudget> findFirstDailyBudgetByMemberProfileIdList(@Param("memberProfileId") Long memberProfileId, Pageable pageable);
+    
+    default Optional<DailyBudget> findFirstDailyBudgetByMemberProfileId(Long memberProfileId) {
+        List<DailyBudget> results = findFirstDailyBudgetByMemberProfileIdList(memberProfileId, Pageable.ofSize(1));
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
 
     @Query("select b from Budget b where type(b) = MonthlyBudget and b.memberProfile.id = :memberProfileId")
     List<MonthlyBudget> findMonthlyBudgetsViaType(@Param("memberProfileId") Long memberProfileId);
 
     @Query("select b from Budget b where type(b) = MonthlyBudget and b.memberProfile.id = :memberProfileId order by treat(b as MonthlyBudget).yearMonth desc")
-    Optional<MonthlyBudget> findFirstMonthlyBudgetByMemberProfileId(@Param("memberProfileId") Long memberProfileId);
+    List<MonthlyBudget> findFirstMonthlyBudgetByMemberProfileIdList(@Param("memberProfileId") Long memberProfileId, Pageable pageable);
+    
+    default Optional<MonthlyBudget> findFirstMonthlyBudgetByMemberProfileId(Long memberProfileId) {
+        List<MonthlyBudget> results = findFirstMonthlyBudgetByMemberProfileIdList(memberProfileId, Pageable.ofSize(1));
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
 
     @Query("select b from Budget b where type(b) = DailyBudget and b.memberProfile.id = :profileId and treat(b as DailyBudget).date = :date")
     Optional<DailyBudget> findDailyBudgetByMemberProfileIdAndDate(Long profileId, LocalDate date);

--- a/src/main/java/com/stcom/smartmealtable/repository/BudgetRepository.java
+++ b/src/main/java/com/stcom/smartmealtable/repository/BudgetRepository.java
@@ -3,6 +3,8 @@ package com.stcom.smartmealtable.repository;
 import com.stcom.smartmealtable.domain.Budget.Budget;
 import com.stcom.smartmealtable.domain.Budget.DailyBudget;
 import com.stcom.smartmealtable.domain.Budget.MonthlyBudget;
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +24,17 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
     @Query("select b from Budget b where type(b) = MonthlyBudget and b.memberProfile.id = :memberProfileId order by treat(b as MonthlyBudget).yearMonth desc")
     Optional<MonthlyBudget> findFirstMonthlyBudgetByMemberProfileId(@Param("memberProfileId") Long memberProfileId);
+
+    @Query("select b from Budget b where type(b) = DailyBudget and b.memberProfile.id = :profileId and treat(b as DailyBudget).date = :date")
+    Optional<DailyBudget> findDailyBudgetByMemberProfileIdAndDate(Long profileId, LocalDate date);
+
+    @Query("select b from Budget b where type(b) = MonthlyBudget and b.memberProfile.id = :profileId and treat(b as MonthlyBudget).yearMonth = :date")
+    Optional<MonthlyBudget> findMonthlyBudgetByMemberProfileIdAndDate(Long profileId, LocalDate date);
+
+    @Query("select b from Budget b where type(b) = MonthlyBudget and b.memberProfile.id = :profileId and treat(b as MonthlyBudget).yearMonth = :yearMonth")
+    Optional<MonthlyBudget> findMonthlyBudgetByMemberProfileIdAndYearMonth(Long profileId, YearMonth yearMonth);
+
+    @Query("select b from Budget b where type(b) = DailyBudget and b.memberProfile.id = :profileId and treat(b as DailyBudget).date between :startOfWeek and :endOfWeek")
+    List<DailyBudget> findDailyBudgetsByMemberProfileIdAndDateBetween(Long profileId, LocalDate startOfWeek,
+                                                                      LocalDate endOfWeek);
 }

--- a/src/main/java/com/stcom/smartmealtable/repository/BudgetRepository.java
+++ b/src/main/java/com/stcom/smartmealtable/repository/BudgetRepository.java
@@ -18,8 +18,9 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     List<DailyBudget> findDailyBudgetsViaType(@Param("memberProfileId") Long memberProfileId);
 
     @Query("select b from Budget b where type(b) = DailyBudget and b.memberProfile.id = :memberProfileId order by treat(b as DailyBudget).date desc")
-    List<DailyBudget> findFirstDailyBudgetByMemberProfileIdList(@Param("memberProfileId") Long memberProfileId, Pageable pageable);
-    
+    List<DailyBudget> findFirstDailyBudgetByMemberProfileIdList(@Param("memberProfileId") Long memberProfileId,
+                                                                Pageable pageable);
+
     default Optional<DailyBudget> findFirstDailyBudgetByMemberProfileId(Long memberProfileId) {
         List<DailyBudget> results = findFirstDailyBudgetByMemberProfileIdList(memberProfileId, Pageable.ofSize(1));
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
@@ -29,8 +30,9 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     List<MonthlyBudget> findMonthlyBudgetsViaType(@Param("memberProfileId") Long memberProfileId);
 
     @Query("select b from Budget b where type(b) = MonthlyBudget and b.memberProfile.id = :memberProfileId order by treat(b as MonthlyBudget).yearMonth desc")
-    List<MonthlyBudget> findFirstMonthlyBudgetByMemberProfileIdList(@Param("memberProfileId") Long memberProfileId, Pageable pageable);
-    
+    List<MonthlyBudget> findFirstMonthlyBudgetByMemberProfileIdList(@Param("memberProfileId") Long memberProfileId,
+                                                                    Pageable pageable);
+
     default Optional<MonthlyBudget> findFirstMonthlyBudgetByMemberProfileId(Long memberProfileId) {
         List<MonthlyBudget> results = findFirstMonthlyBudgetByMemberProfileIdList(memberProfileId, Pageable.ofSize(1));
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
@@ -38,9 +40,6 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
     @Query("select b from Budget b where type(b) = DailyBudget and b.memberProfile.id = :profileId and treat(b as DailyBudget).date = :date")
     Optional<DailyBudget> findDailyBudgetByMemberProfileIdAndDate(Long profileId, LocalDate date);
-
-    @Query("select b from Budget b where type(b) = MonthlyBudget and b.memberProfile.id = :profileId and treat(b as MonthlyBudget).yearMonth = :date")
-    Optional<MonthlyBudget> findMonthlyBudgetByMemberProfileIdAndDate(Long profileId, LocalDate date);
 
     @Query("select b from Budget b where type(b) = MonthlyBudget and b.memberProfile.id = :profileId and treat(b as MonthlyBudget).yearMonth = :yearMonth")
     Optional<MonthlyBudget> findMonthlyBudgetByMemberProfileIdAndYearMonth(Long profileId, YearMonth yearMonth);

--- a/src/main/java/com/stcom/smartmealtable/service/BudgetService.java
+++ b/src/main/java/com/stcom/smartmealtable/service/BudgetService.java
@@ -1,5 +1,7 @@
 package com.stcom.smartmealtable.service;
 
+import static java.time.DayOfWeek.MONDAY;
+
 import com.stcom.smartmealtable.domain.Budget.DailyBudget;
 import com.stcom.smartmealtable.domain.Budget.MonthlyBudget;
 import com.stcom.smartmealtable.domain.member.MemberProfile;
@@ -8,6 +10,7 @@ import com.stcom.smartmealtable.repository.MemberProfileRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,5 +47,60 @@ public class BudgetService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 프로필로 접근"));
         DailyBudget dailyBudget = new DailyBudget(profile, BigDecimal.valueOf(limit), LocalDate.now());
         budgetRepository.save(dailyBudget);
+    }
+
+
+    public DailyBudget getDailyBudgetBy(Long profileId, LocalDate date) {
+        return budgetRepository.findDailyBudgetByMemberProfileIdAndDate(profileId, date).orElseThrow(() ->
+                new IllegalArgumentException("존재하지 않는 프로필로 접근")
+        );
+    }
+
+    @Transactional
+    public void registerDefaultDailyBudgetBy(Long profileId, Long dailyLimit, LocalDate startDate) {
+        MemberProfile profile = memberProfileRepository.findById(profileId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 프로필로 접근"));
+        // 일일 예산은 오늘 ~ 이번달 말일까지 디폴트 daily Limit로 여러 개 생성해준다.
+        for (LocalDate date = startDate; date.getMonth() == startDate.getMonth(); date = date.plusDays(1)) {
+            DailyBudget dailyBudget = new DailyBudget(profile, BigDecimal.valueOf(dailyLimit), date);
+            budgetRepository.save(dailyBudget);
+        }
+    }
+
+    @Transactional
+    public void registerDefaultMonthlyBudgetBy(Long profileId, Long monthlyLimit,
+                                               YearMonth startYearMonth) {
+
+        MemberProfile profile = memberProfileRepository.findById(profileId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 프로필로 접근"));
+        // 월간 예산은 이번달에 한 번만 생성해준다.
+        MonthlyBudget monthlyBudget = new MonthlyBudget(profile, BigDecimal.valueOf(monthlyLimit), startYearMonth);
+        budgetRepository.save(monthlyBudget);
+    }
+
+    public MonthlyBudget getMonthlyBudgetBy(Long profileId, YearMonth yearMonth) {
+        return budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(profileId, yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 프로필로 접근"));
+    }
+
+    public List<DailyBudget> getDailyBudgetsByWeek(Long profileId, LocalDate date) {
+        LocalDate startOfWeek = date.with(MONDAY);
+        LocalDate endOfWeek = startOfWeek.plusDays(6);
+        return budgetRepository.findDailyBudgetsByMemberProfileIdAndDateBetween(profileId, startOfWeek, endOfWeek);
+    }
+
+    @Transactional
+    public void editMonthlyBudgetCustom(Long profileId, YearMonth yearMonth, Long limit) {
+        budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(profileId,
+                        yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 프로필로 접근"))
+                .changeLimit(BigDecimal.valueOf(limit));
+    }
+
+    @Transactional
+    public void editDailyBudgetCustom(Long profileId, LocalDate date, Long limit) {
+        budgetRepository.findDailyBudgetByMemberProfileIdAndDate(profileId, date)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 프로필로 접근"))
+                .changeLimit(BigDecimal.valueOf(limit));
     }
 }

--- a/src/main/java/com/stcom/smartmealtable/service/BudgetService.java
+++ b/src/main/java/com/stcom/smartmealtable/service/BudgetService.java
@@ -52,7 +52,7 @@ public class BudgetService {
 
     public DailyBudget getDailyBudgetBy(Long profileId, LocalDate date) {
         return budgetRepository.findDailyBudgetByMemberProfileIdAndDate(profileId, date).orElseThrow(() ->
-                new IllegalArgumentException("존재하지 않는 프로필로 접근")
+                new IllegalArgumentException("예산이 존재하지 않습니다.")
         );
     }
 

--- a/src/main/java/com/stcom/smartmealtable/web/WebConfig.java
+++ b/src/main/java/com/stcom/smartmealtable/web/WebConfig.java
@@ -2,9 +2,11 @@ package com.stcom.smartmealtable.web;
 
 import com.stcom.smartmealtable.web.argumentresolver.UserContextArgumentResolver;
 import com.stcom.smartmealtable.web.interceptor.JwtAuthenticationInterceptor;
+import com.stcom.smartmealtable.web.validation.YearMonthAnnotationFormatterFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -20,6 +22,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(userContextArgumentResolver);
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addFormatterForFieldAnnotation(new YearMonthAnnotationFormatterFactory());
     }
 
     @Override

--- a/src/main/java/com/stcom/smartmealtable/web/controller/MemberProfileController.java
+++ b/src/main/java/com/stcom/smartmealtable/web/controller/MemberProfileController.java
@@ -180,29 +180,29 @@ public class MemberProfileController {
 
     @GetMapping("/me/budgets/monthly/{yearMonth}")
     public ApiResponse<MonthlyBudgetResponse> monthlyBudgetByDate(@UserContext MemberDto memberDto,
-                                                                  @PathVariable("yearMonth") @YearMonthFormat String yearMonth) {
+                                                                  @PathVariable("yearMonth") @YearMonthFormat YearMonth yearMonth) {
         MonthlyBudget monthlyBudget = budgetService.getMonthlyBudgetBy(memberDto.getProfileId(),
-                YearMonth.parse(yearMonth));
+                yearMonth);
 
         return ApiResponse.createSuccess(MonthlyBudgetResponse.of(monthlyBudget));
     }
 
     @PutMapping("/me/budgets/monthly/{yearMonth}/default")
     public ApiResponse<Void> registerDefaultMonthlyBudget(@UserContext MemberDto memberDto,
-                                                          @PathVariable("yearMonth") @YearMonthFormat String yearMonth,
+                                                          @PathVariable("yearMonth") @YearMonthFormat YearMonth yearMonth,
                                                           @RequestParam("limit") Long limit) {
         budgetService.registerDefaultMonthlyBudgetBy(memberDto.getProfileId(),
-                limit, YearMonth.parse(yearMonth));
+                limit, yearMonth);
 
         return ApiResponse.createSuccessWithNoContent();
     }
 
     @PatchMapping("/me/budgets/monthly/{yearMonth}")
     public ApiResponse<Void> editMonthlyBudget(@UserContext MemberDto memberDto,
-                                               @PathVariable("yearMonth") @YearMonthFormat String yearMonth,
+                                               @PathVariable("yearMonth") @YearMonthFormat YearMonth yearMonth,
                                                @RequestParam("limit") Long limit) {
         budgetService.editMonthlyBudgetCustom(memberDto.getProfileId(),
-                YearMonth.parse(yearMonth), limit);
+                yearMonth, limit);
 
         return ApiResponse.createSuccessWithNoContent();
     }

--- a/src/main/java/com/stcom/smartmealtable/web/controller/MemberProfileController.java
+++ b/src/main/java/com/stcom/smartmealtable/web/controller/MemberProfileController.java
@@ -178,7 +178,7 @@ public class MemberProfileController {
         return ApiResponse.createSuccess(responses);
     }
 
-    @GetMapping("/me/budgets/month/{yearMonth}")
+    @GetMapping("/me/budgets/monthly/{yearMonth}")
     public ApiResponse<MonthlyBudgetResponse> monthlyBudgetByDate(@UserContext MemberDto memberDto,
                                                                   @PathVariable("yearMonth") @YearMonthFormat String yearMonth) {
         MonthlyBudget monthlyBudget = budgetService.getMonthlyBudgetBy(memberDto.getProfileId(),
@@ -187,7 +187,7 @@ public class MemberProfileController {
         return ApiResponse.createSuccess(MonthlyBudgetResponse.of(monthlyBudget));
     }
 
-    @PutMapping("/me/budgets/month/{yearMonth}/default")
+    @PutMapping("/me/budgets/monthly/{yearMonth}/default")
     public ApiResponse<Void> registerDefaultMonthlyBudget(@UserContext MemberDto memberDto,
                                                           @PathVariable("yearMonth") @YearMonthFormat String yearMonth,
                                                           @RequestParam("limit") Long limit) {

--- a/src/main/java/com/stcom/smartmealtable/web/controller/MemberProfileController.java
+++ b/src/main/java/com/stcom/smartmealtable/web/controller/MemberProfileController.java
@@ -17,12 +17,15 @@ import com.stcom.smartmealtable.service.MemberProfileService;
 import com.stcom.smartmealtable.service.dto.MemberDto;
 import com.stcom.smartmealtable.web.argumentresolver.UserContext;
 import com.stcom.smartmealtable.web.dto.ApiResponse;
+import com.stcom.smartmealtable.web.validation.YearMonthFormat;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -140,14 +143,14 @@ public class MemberProfileController {
      */
     @GetMapping("/me/budgets/daily/{date}")
     public ApiResponse<DailyBudgetResponse> dailyBudgetByDate(@UserContext MemberDto memberDto,
-                                                              @PathVariable("date") String date) {
+                                                              @PathVariable("date") @DateTimeFormat(iso = ISO.DATE) String date) {
         DailyBudget dailyBudget = budgetService.getDailyBudgetBy(memberDto.getProfileId(), LocalDate.parse(date));
         return ApiResponse.createSuccess(DailyBudgetResponse.of(dailyBudget));
     }
 
     @PutMapping("/me/budgets/daily/{date}/default")
     public ApiResponse<Void> registerDefaultDailyBudget(@UserContext MemberDto memberDto,
-                                                        @PathVariable("date") String date,
+                                                        @PathVariable("date") @DateTimeFormat(iso = ISO.DATE) String date,
                                                         @RequestParam("limit") Long limit) {
         budgetService.registerDefaultDailyBudgetBy(memberDto.getProfileId(), limit, LocalDate.parse(date));
         return ApiResponse.createSuccessWithNoContent();
@@ -155,7 +158,7 @@ public class MemberProfileController {
 
     @PatchMapping("/me/budgets/daily/{date}")
     public ApiResponse<Void> editDailyBudget(@UserContext MemberDto memberDto,
-                                             @PathVariable("date") String date,
+                                             @PathVariable("date") @DateTimeFormat(iso = ISO.DATE) String date,
                                              @RequestParam("limit") Long limit) {
         budgetService.editDailyBudgetCustom(memberDto.getProfileId(), LocalDate.parse(date), limit);
         return ApiResponse.createSuccessWithNoContent();
@@ -164,7 +167,7 @@ public class MemberProfileController {
     // 해당 일자가 속한 일일 예산 주간 데이터 조회
     @GetMapping("/me/budgets/daily/{date}/week")
     public ApiResponse<List<DailyBudgetResponse>> dailyBudgetWeekByDate(@UserContext MemberDto memberDto,
-                                                                        @PathVariable("date") String date) {
+                                                                        @PathVariable("date") @DateTimeFormat(iso = ISO.DATE) String date) {
         List<DailyBudget> dailyBudgets = budgetService.getDailyBudgetsByWeek(memberDto.getProfileId(),
                 LocalDate.parse(date));
 
@@ -177,7 +180,7 @@ public class MemberProfileController {
 
     @GetMapping("/me/budgets/month/{yearMonth}")
     public ApiResponse<MonthlyBudgetResponse> monthlyBudgetByDate(@UserContext MemberDto memberDto,
-                                                                  @PathVariable("yearMonth") String yearMonth) {
+                                                                  @PathVariable("yearMonth") @YearMonthFormat String yearMonth) {
         MonthlyBudget monthlyBudget = budgetService.getMonthlyBudgetBy(memberDto.getProfileId(),
                 YearMonth.parse(yearMonth));
 
@@ -186,7 +189,7 @@ public class MemberProfileController {
 
     @PutMapping("/me/budgets/month/{yearMonth}/default")
     public ApiResponse<Void> registerDefaultMonthlyBudget(@UserContext MemberDto memberDto,
-                                                          @PathVariable("yearMonth") String yearMonth,
+                                                          @PathVariable("yearMonth") @YearMonthFormat String yearMonth,
                                                           @RequestParam("limit") Long limit) {
         budgetService.registerDefaultMonthlyBudgetBy(memberDto.getProfileId(),
                 limit, YearMonth.parse(yearMonth));
@@ -196,7 +199,7 @@ public class MemberProfileController {
 
     @PatchMapping("/me/budgets/monthly/{yearMonth}")
     public ApiResponse<Void> editMonthlyBudget(@UserContext MemberDto memberDto,
-                                               @PathVariable("yearMonth") String yearMonth,
+                                               @PathVariable("yearMonth") @YearMonthFormat String yearMonth,
                                                @RequestParam("limit") Long limit) {
         budgetService.editMonthlyBudgetCustom(memberDto.getProfileId(),
                 YearMonth.parse(yearMonth), limit);

--- a/src/main/java/com/stcom/smartmealtable/web/validation/YearMonthAnnotationFormatterFactory.java
+++ b/src/main/java/com/stcom/smartmealtable/web/validation/YearMonthAnnotationFormatterFactory.java
@@ -1,0 +1,50 @@
+package com.stcom.smartmealtable.web.validation;
+
+import java.text.ParseException;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.format.AnnotationFormatterFactory;
+import org.springframework.format.Parser;
+import org.springframework.format.Printer;
+
+public class YearMonthAnnotationFormatterFactory implements AnnotationFormatterFactory<YearMonthFormat> {
+
+    private static final Set<Class<?>> FIELD_TYPES =
+            Set.copyOf(List.of(YearMonth.class));
+
+    @Override
+    public Set<Class<?>> getFieldTypes() {
+        return FIELD_TYPES;
+    }
+
+    @Override
+    public Printer<?> getPrinter(YearMonthFormat annotation, Class<?> fieldType) {
+        return new YearMonthFormatter(annotation.pattern());
+    }
+
+    @Override
+    public Parser<?> getParser(YearMonthFormat annotation, Class<?> fieldType) {
+        return new YearMonthFormatter(annotation.pattern());
+    }
+
+    private static class YearMonthFormatter implements Printer<YearMonth>, Parser<YearMonth> {
+        private final DateTimeFormatter formatter;
+
+        public YearMonthFormatter(String pattern) {
+            this.formatter = DateTimeFormatter.ofPattern(pattern);
+        }
+
+        @Override
+        public String print(YearMonth yearMonth, Locale locale) {
+            return yearMonth.format(formatter);
+        }
+
+        @Override
+        public YearMonth parse(String text, Locale locale) throws ParseException {
+            return YearMonth.parse(text, formatter);
+        }
+    }
+}

--- a/src/main/java/com/stcom/smartmealtable/web/validation/YearMonthFormat.java
+++ b/src/main/java/com/stcom/smartmealtable/web/validation/YearMonthFormat.java
@@ -1,0 +1,15 @@
+package com.stcom.smartmealtable.web.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface YearMonthFormat {
+
+    String pattern() default "yyyy-MM";
+}

--- a/src/test/java/com/stcom/smartmealtable/domain/Budget/BudgetDomainIntegrationTest.java
+++ b/src/test/java/com/stcom/smartmealtable/domain/Budget/BudgetDomainIntegrationTest.java
@@ -1,0 +1,280 @@
+package com.stcom.smartmealtable.domain.Budget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.stcom.smartmealtable.domain.member.MemberProfile;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BudgetDomainIntegrationTest {
+
+    private MemberProfile memberProfile;
+
+    @BeforeEach
+    void setUp() {
+        memberProfile = new MemberProfile();
+    }
+
+    @DisplayName("예산 상속 구조와 다형성이 올바르게 작동한다")
+    @Test
+    void budgetPolymorphismTest() {
+        // given
+        List<Budget> budgets = new ArrayList<>();
+        
+        DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(20000), LocalDate.now());
+        MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(500000), YearMonth.now());
+        
+        budgets.add(dailyBudget);
+        budgets.add(monthlyBudget);
+
+        // when & then - 다형성을 통한 공통 동작 확인
+        for (Budget budget : budgets) {
+            // 초기 상태 검증
+            assertThat(budget.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+            assertThat(budget.isOverLimit()).isFalse();
+            
+            // 지출 추가
+            budget.addSpent(BigDecimal.valueOf(10000));
+            assertThat(budget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(10000));
+            
+            // 사용 가능 금액 계산
+            BigDecimal expectedAvailable = budget.getLimit().subtract(BigDecimal.valueOf(10000));
+            assertThat(budget.getAvailableAmount()).isEqualTo(expectedAvailable);
+        }
+
+        // 각 타입별 고유 속성 확인
+        assertThat(dailyBudget).isInstanceOf(DailyBudget.class);
+        assertThat(monthlyBudget).isInstanceOf(MonthlyBudget.class);
+        
+        assertThat(dailyBudget.getDate()).isNotNull();
+        assertThat(monthlyBudget.getYearMonth()).isNotNull();
+    }
+
+    @DisplayName("예산 한도 변경 시 비즈니스 로직이 올바르게 동작한다")
+    @Test
+    void budgetLimitChangeBusinessLogic() {
+        // given
+        DailyBudget budget = new DailyBudget(memberProfile, BigDecimal.valueOf(30000), LocalDate.now());
+        budget.addSpent(20000); // 20,000원 지출
+
+        // when & then - 한도 증가
+        budget.changeLimit(BigDecimal.valueOf(50000));
+        assertThat(budget.getLimit()).isEqualTo(BigDecimal.valueOf(50000));
+        assertThat(budget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(30000));
+        assertThat(budget.isOverLimit()).isFalse();
+
+        // when & then - 한도 감소 (한도 초과 상황)
+        budget.changeLimit(BigDecimal.valueOf(15000));
+        assertThat(budget.getLimit()).isEqualTo(BigDecimal.valueOf(15000));
+        assertThat(budget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(-5000));
+        assertThat(budget.isOverLimit()).isTrue();
+    }
+
+    @DisplayName("복잡한 지출 패턴 계산")
+    @Test
+    void complexSpendingPatternCalculation() {
+        // given
+        DailyBudget weeklyBudget = new DailyBudget(
+                memberProfile, 
+                BigDecimal.valueOf(150000), 
+                LocalDate.now()
+        );
+
+        // 다양한 금액으로 여러 번 지출
+        weeklyBudget.addSpent(25000);
+        weeklyBudget.addSpent(15000); 
+        weeklyBudget.addSpent(7500);
+        weeklyBudget.addSpent(12500); // 총 60,000원 지출
+
+        // when
+        BigDecimal totalSpent = weeklyBudget.getSpendAmount();
+        BigDecimal remaining = weeklyBudget.getAvailableAmount();
+        
+        // 사용률 계산: 60,000 / 150,000 = 0.4 (40%)
+        BigDecimal usageRate = totalSpent
+                .divide(weeklyBudget.getLimit(), 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+
+        // then - 정확한 계산 검증
+        assertThat(totalSpent).isEqualTo(BigDecimal.valueOf(60000));
+        assertThat(remaining).isEqualTo(BigDecimal.valueOf(90000)); // 150,000 - 60,000
+        
+        BigDecimal expectedUsageRate = BigDecimal.valueOf(40.00);
+        assertThat(usageRate).isCloseTo(expectedUsageRate, within(BigDecimal.valueOf(0.01)));
+    }
+
+    @DisplayName("예산 리셋 기능")
+    @Test
+    void budgetResetFunctionality() {
+        // given
+        DailyBudget budget = new DailyBudget(
+                memberProfile, 
+                BigDecimal.valueOf(50000), 
+                LocalDate.now()
+        );
+        
+        budget.addSpent(30000);
+        assertThat(budget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(30000));
+
+        // when - 예산 지출 리셋
+        budget.resetSpent();
+
+        // then
+        assertThat(budget.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+        assertThat(budget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(50000));
+        
+        // 사용률 = 0 / 50000 * 100 = 0% (0 나누기 문제 없음)
+        BigDecimal usageRate = budget.getSpendAmount()
+                .multiply(BigDecimal.valueOf(100))
+                .divide(budget.getLimit(), 2, RoundingMode.HALF_UP);
+        assertThat(usageRate).isEqualTo(BigDecimal.ZERO);
+    }
+
+    @DisplayName("예산의 부동소수점 정밀도 테스트")
+    @Test
+    void budgetFloatingPointPrecisionTest() {
+        // given
+        MonthlyBudget budget = new MonthlyBudget(
+                memberProfile, 
+                BigDecimal.valueOf(1000000), 
+                YearMonth.of(2025, 6)
+        );
+
+        // when - 소수점을 포함한 복잡한 계산
+        budget.addSpent(333333); // 33.3333%
+        budget.addSpent(166667); // 추가로 16.6667%
+
+        // then
+        BigDecimal totalSpent = budget.getSpendAmount();
+        
+        // 사용률 계산: 500,000 / 1,000,000 = 0.5 (50%)
+        BigDecimal usageRate = totalSpent
+                .divide(budget.getLimit(), 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+        
+        assertThat(totalSpent).isEqualTo(BigDecimal.valueOf(500000));
+        
+        BigDecimal expectedUsageRate = BigDecimal.valueOf(50.00);
+        assertThat(usageRate).isCloseTo(expectedUsageRate, within(BigDecimal.valueOf(0.01)));
+        
+        // 남은 금액 검증
+        assertThat(budget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(500000));
+        assertThat(budget.isOverLimit()).isFalse();
+    }
+
+    @DisplayName("예산 한도 초과 경계값 테스트")
+    @Test
+    void budgetOverLimitBoundaryTest() {
+        // given
+        DailyBudget budget = new DailyBudget(memberProfile, BigDecimal.valueOf(100000), LocalDate.now());
+
+        // when & then - 한도와 정확히 같은 금액 지출
+        budget.addSpent(100000);
+        assertThat(budget.isOverLimit()).isFalse();
+        assertThat(budget.getAvailableAmount()).isEqualTo(BigDecimal.ZERO);
+
+        // when & then - 1원 초과
+        budget.addSpent(1);
+        assertThat(budget.isOverLimit()).isTrue();
+        assertThat(budget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(-1));
+
+        // when & then - 리셋 후 1원 미만 지출
+        budget.resetSpent();
+        budget.addSpent(99999);
+        assertThat(budget.isOverLimit()).isFalse();
+        assertThat(budget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(1));
+    }
+
+    @DisplayName("월별 예산과 일일 예산의 독립성 확인")
+    @Test
+    void monthlyAndDailyBudgetIndependence() {
+        // given
+        YearMonth currentMonth = YearMonth.now();
+        LocalDate today = LocalDate.now();
+        
+        MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(500000), currentMonth);
+        DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(20000), today);
+
+        // when - 각각 다른 지출 추가
+        monthlyBudget.addSpent(300000);
+        dailyBudget.addSpent(15000);
+
+        // then - 독립적인 계산 확인
+        assertThat(monthlyBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(300000));
+        assertThat(monthlyBudget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(200000));
+        assertThat(monthlyBudget.isOverLimit()).isFalse();
+
+        assertThat(dailyBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(15000));
+        assertThat(dailyBudget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(5000));
+        assertThat(dailyBudget.isOverLimit()).isFalse();
+
+        // 서로의 상태에 영향을 주지 않음
+        monthlyBudget.addSpent(250000); // 월별 예산 초과
+        assertThat(monthlyBudget.isOverLimit()).isTrue();
+        assertThat(dailyBudget.isOverLimit()).isFalse(); // 일일 예산은 영향 없음
+    }
+
+    @DisplayName("예산 객체의 불변 속성 확인")
+    @Test
+    void budgetImmutablePropertiesTest() {
+        // given
+        LocalDate testDate = LocalDate.of(2025, 6, 15);
+        YearMonth testYearMonth = YearMonth.of(2025, 6);
+        
+        DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(30000), testDate);
+        MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(800000), testYearMonth);
+
+        // when - 예산에 지출 추가 및 리셋
+        dailyBudget.addSpent(20000);
+        dailyBudget.resetSpent();
+        dailyBudget.changeLimit(BigDecimal.valueOf(50000));
+
+        monthlyBudget.addSpent(400000);
+        monthlyBudget.resetSpent();
+        monthlyBudget.changeLimit(BigDecimal.valueOf(1000000));
+
+        // then - 기본 속성들은 변경되지 않음
+        assertThat(dailyBudget.getDate()).isEqualTo(testDate);
+        assertThat(dailyBudget.getMemberProfile()).isEqualTo(memberProfile);
+        
+        assertThat(monthlyBudget.getYearMonth()).isEqualTo(testYearMonth);
+        assertThat(monthlyBudget.getMemberProfile()).isEqualTo(memberProfile);
+    }
+
+    @DisplayName("예산 생성 시 초기값 검증")
+    @Test
+    void budgetInitialValueValidation() {
+        // given & when
+        LocalDate today = LocalDate.now();
+        YearMonth currentMonth = YearMonth.now();
+        BigDecimal limit = BigDecimal.valueOf(100000);
+        
+        DailyBudget dailyBudget = new DailyBudget(memberProfile, limit, today);
+        MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, limit, currentMonth);
+
+        // then - 초기값 검증
+        assertThat(dailyBudget.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+        assertThat(dailyBudget.getLimit()).isEqualTo(limit);
+        assertThat(dailyBudget.getAvailableAmount()).isEqualTo(limit);
+        assertThat(dailyBudget.isOverLimit()).isFalse();
+        assertThat(dailyBudget.getDate()).isEqualTo(today);
+        assertThat(dailyBudget.getMemberProfile()).isEqualTo(memberProfile);
+
+        assertThat(monthlyBudget.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+        assertThat(monthlyBudget.getLimit()).isEqualTo(limit);
+        assertThat(monthlyBudget.getAvailableAmount()).isEqualTo(limit);
+        assertThat(monthlyBudget.isOverLimit()).isFalse();
+        assertThat(monthlyBudget.getYearMonth()).isEqualTo(currentMonth);
+        assertThat(monthlyBudget.getMemberProfile()).isEqualTo(memberProfile);
+    }
+} 

--- a/src/test/java/com/stcom/smartmealtable/integration/BudgetIntegrationTest.java
+++ b/src/test/java/com/stcom/smartmealtable/integration/BudgetIntegrationTest.java
@@ -1,0 +1,309 @@
+package com.stcom.smartmealtable.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.stcom.smartmealtable.domain.Budget.DailyBudget;
+import com.stcom.smartmealtable.domain.Budget.MonthlyBudget;
+import com.stcom.smartmealtable.domain.member.Member;
+import com.stcom.smartmealtable.domain.member.MemberProfile;
+import com.stcom.smartmealtable.repository.BudgetRepository;
+import com.stcom.smartmealtable.repository.MemberProfileRepository;
+import com.stcom.smartmealtable.repository.MemberRepository;
+import com.stcom.smartmealtable.service.BudgetService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class BudgetIntegrationTest {
+
+    @Autowired
+    private BudgetService budgetService;
+
+    @Autowired
+    private BudgetRepository budgetRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MemberProfileRepository memberProfileRepository;
+
+    private Member member;
+    private MemberProfile memberProfile;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("integration@test.com")
+                .rawPassword("testPassword!")
+                .build();
+        memberRepository.save(member);
+
+        memberProfile = MemberProfile.builder()
+                .nickName("integrationTestUser")
+                .member(member)
+                .build();
+        memberProfileRepository.save(memberProfile);
+    }
+
+    @DisplayName("일일 예산 생성부터 지출 추가, 한도 초과 확인까지의 전체 시나리오 테스트")
+    @Test
+    void dailyBudgetCompleteScenario() {
+        // given - 일일 예산 생성
+        LocalDate today = LocalDate.now();
+        Long dailyLimit = 30000L;
+        DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(dailyLimit), today);
+        budgetRepository.save(dailyBudget);
+
+        // when & then - 1. 초기 상태 확인
+        DailyBudget savedBudget = budgetService.getDailyBudgetBy(memberProfile.getId(), today);
+        assertThat(savedBudget.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+        assertThat(savedBudget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(dailyLimit));
+        assertThat(savedBudget.isOverLimit()).isFalse();
+
+        // when & then - 2. 첫 번째 지출 추가 (아직 한도 내)
+        savedBudget.addSpent(15000);
+        budgetRepository.save(savedBudget);
+        
+        DailyBudget afterFirstSpent = budgetService.getDailyBudgetBy(memberProfile.getId(), today);
+        assertThat(afterFirstSpent.getSpendAmount()).isEqualTo(BigDecimal.valueOf(15000));
+        assertThat(afterFirstSpent.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(15000));
+        assertThat(afterFirstSpent.isOverLimit()).isFalse();
+
+        // when & then - 3. 두 번째 지출 추가 (한도 초과)
+        afterFirstSpent.addSpent(20000);
+        budgetRepository.save(afterFirstSpent);
+        
+        DailyBudget afterSecondSpent = budgetService.getDailyBudgetBy(memberProfile.getId(), today);
+        assertThat(afterSecondSpent.getSpendAmount()).isEqualTo(BigDecimal.valueOf(35000));
+        assertThat(afterSecondSpent.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(-5000));
+        assertThat(afterSecondSpent.isOverLimit()).isTrue();
+
+        // when & then - 4. 지출 리셋
+        afterSecondSpent.resetSpent();
+        budgetRepository.save(afterSecondSpent);
+        
+        DailyBudget afterReset = budgetService.getDailyBudgetBy(memberProfile.getId(), today);
+        assertThat(afterReset.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+        assertThat(afterReset.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(dailyLimit));
+        assertThat(afterReset.isOverLimit()).isFalse();
+    }
+
+    @DisplayName("월별 예산 생성부터 지출 추가, 한도 변경까지의 전체 시나리오 테스트")
+    @Test
+    void monthlyBudgetCompleteScenario() {
+        // given - 월별 예산 생성
+        YearMonth currentMonth = YearMonth.now();
+        Long monthlyLimit = 500000L;
+        MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(monthlyLimit), currentMonth);
+        budgetRepository.save(monthlyBudget);
+
+        // when & then - 1. 초기 상태 확인
+        MonthlyBudget savedBudget = budgetService.getMonthlyBudgetBy(memberProfile.getId(), currentMonth);
+        assertThat(savedBudget.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+        assertThat(savedBudget.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(monthlyLimit));
+        assertThat(savedBudget.isOverLimit()).isFalse();
+
+        // when & then - 2. 여러 번에 걸친 지출 추가
+        savedBudget.addSpent(BigDecimal.valueOf(150000)); // 첫 번째 지출
+        savedBudget.addSpent(200000); // 두 번째 지출 (int)
+        savedBudget.addSpent(99999.99); // 세 번째 지출 (double)
+        budgetRepository.save(savedBudget);
+        
+        MonthlyBudget afterSpending = budgetService.getMonthlyBudgetBy(memberProfile.getId(), currentMonth);
+        assertThat(afterSpending.getSpendAmount()).isEqualTo(BigDecimal.valueOf(449999.99));
+        assertThat(afterSpending.getAvailableAmount()).isEqualTo(BigDecimal.valueOf(50000.01));
+        assertThat(afterSpending.isOverLimit()).isFalse();
+
+        // when & then - 3. 한도 변경
+        Long newLimit = 400000L;
+        budgetService.editMonthlyBudgetCustom(memberProfile.getId(), currentMonth, newLimit);
+        
+        MonthlyBudget afterLimitChange = budgetService.getMonthlyBudgetBy(memberProfile.getId(), currentMonth);
+        assertThat(afterLimitChange.getLimit()).isEqualTo(BigDecimal.valueOf(newLimit));
+        assertThat(afterLimitChange.getSpendAmount()).isEqualTo(BigDecimal.valueOf(449999.99));
+        assertThat(afterLimitChange.isOverLimit()).isTrue(); // 새 한도로 인해 초과 상태
+    }
+
+    @DisplayName("한 달간의 일일 예산을 디폴트로 생성하고 개별 수정하는 시나리오")
+    @Test
+    void monthlyDailyBudgetManagementScenario() {
+        // given - 이번 달 1일부터 디폴트 일일 예산 생성
+        LocalDate firstDayOfMonth = LocalDate.now().withDayOfMonth(1);
+        Long defaultDailyLimit = 20000L;
+
+        // when - 디폴트 일일 예산 생성
+        budgetService.registerDefaultDailyBudgetBy(memberProfile.getId(), defaultDailyLimit, firstDayOfMonth);
+
+        // then - 1. 모든 일일 예산이 생성되었는지 확인
+        List<DailyBudget> allDailyBudgets = budgetRepository.findDailyBudgetsViaType(memberProfile.getId());
+        int daysInMonth = firstDayOfMonth.lengthOfMonth();
+        assertThat(allDailyBudgets).hasSize(daysInMonth);
+
+        // when & then - 2. 특정 날짜의 예산 한도 개별 수정
+        LocalDate specificDate = firstDayOfMonth.plusDays(10);
+        Long newLimitForSpecificDate = 35000L;
+        budgetService.editDailyBudgetCustom(memberProfile.getId(), specificDate, newLimitForSpecificDate);
+
+        DailyBudget modifiedBudget = budgetService.getDailyBudgetBy(memberProfile.getId(), specificDate);
+        assertThat(modifiedBudget.getLimit()).isEqualTo(BigDecimal.valueOf(newLimitForSpecificDate));
+
+        // when & then - 3. 다른 날짜의 예산은 그대로인지 확인
+        LocalDate anotherDate = firstDayOfMonth.plusDays(5);
+        DailyBudget unchangedBudget = budgetService.getDailyBudgetBy(memberProfile.getId(), anotherDate);
+        assertThat(unchangedBudget.getLimit()).isEqualTo(BigDecimal.valueOf(defaultDailyLimit));
+    }
+
+    @DisplayName("주간 예산 조회 및 주간별 지출 패턴 분석 시나리오")
+    @Test
+    void weeklyBudgetAnalysisScenario() {
+        // given - 한 주간의 일일 예산 및 지출 설정
+        LocalDate monday = LocalDate.of(2025, 6, 16); // 월요일
+        Long dailyLimit = 25000L;
+
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = monday.plusDays(i);
+            DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(dailyLimit), date);
+            
+            // 요일별 다른 지출 패턴 설정
+            if (i < 5) { // 평일 (월~금)
+                dailyBudget.addSpent(15000 + i * 2000); // 점진적 증가
+            } else { // 주말 (토~일)
+                dailyBudget.addSpent(30000); // 주말 과소비
+            }
+            
+            budgetRepository.save(dailyBudget);
+        }
+
+        // when - 주간 예산 조회 (수요일 기준)
+        LocalDate wednesday = monday.plusDays(2);
+        List<DailyBudget> weeklyBudgets = budgetService.getDailyBudgetsByWeek(memberProfile.getId(), wednesday);
+
+        // then - 주간 예산 분석
+        assertThat(weeklyBudgets).hasSize(7);
+
+        // 평일 예산 검증
+        for (int i = 0; i < 5; i++) {
+            DailyBudget weekdayBudget = weeklyBudgets.get(i);
+            assertThat(weekdayBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(15000 + i * 2000));
+            assertThat(weekdayBudget.isOverLimit()).isFalse();
+        }
+
+        // 주말 예산 검증 (한도 초과)
+        for (int i = 5; i < 7; i++) {
+            DailyBudget weekendBudget = weeklyBudgets.get(i);
+            assertThat(weekendBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(30000));
+            assertThat(weekendBudget.isOverLimit()).isTrue();
+        }
+
+        // 주간 총 지출 계산
+        BigDecimal totalWeeklySpent = weeklyBudgets.stream()
+                .map(DailyBudget::getSpendAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        
+        BigDecimal expectedTotal = BigDecimal.valueOf(
+                15000 + 17000 + 19000 + 21000 + 23000 + 30000 + 30000); // 155,000원
+        assertThat(totalWeeklySpent).isEqualTo(expectedTotal);
+    }
+
+    @DisplayName("다중 사용자 예산 격리 테스트")
+    @Test
+    void multiUserBudgetIsolationTest() {
+        // given - 두 번째 사용자 생성
+        Member secondMember = Member.builder()
+                .email("second@test.com")
+                .rawPassword("password123!")
+                .build();
+        memberRepository.save(secondMember);
+
+        MemberProfile secondProfile = MemberProfile.builder()
+                .nickName("secondUser")
+                .member(secondMember)
+                .build();
+        memberProfileRepository.save(secondProfile);
+
+        // when - 두 사용자 모두에게 같은 날짜의 예산 생성
+        LocalDate sameDate = LocalDate.now();
+        DailyBudget firstUserBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(20000), sameDate);
+        DailyBudget secondUserBudget = new DailyBudget(secondProfile, BigDecimal.valueOf(30000), sameDate);
+        
+        budgetRepository.save(firstUserBudget);
+        budgetRepository.save(secondUserBudget);
+
+        // when - 각 사용자별로 다른 지출 추가
+        firstUserBudget.addSpent(15000);
+        secondUserBudget.addSpent(25000);
+        
+        budgetRepository.save(firstUserBudget);
+        budgetRepository.save(secondUserBudget);
+
+        // then - 각 사용자의 예산이 독립적으로 관리되는지 확인
+        DailyBudget retrievedFirstBudget = budgetService.getDailyBudgetBy(memberProfile.getId(), sameDate);
+        DailyBudget retrievedSecondBudget = budgetService.getDailyBudgetBy(secondProfile.getId(), sameDate);
+
+        assertThat(retrievedFirstBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(15000));
+        assertThat(retrievedFirstBudget.getLimit()).isEqualTo(BigDecimal.valueOf(20000));
+        assertThat(retrievedFirstBudget.isOverLimit()).isFalse();
+
+        assertThat(retrievedSecondBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(25000));
+        assertThat(retrievedSecondBudget.getLimit()).isEqualTo(BigDecimal.valueOf(30000));
+        assertThat(retrievedSecondBudget.isOverLimit()).isFalse();
+    }
+
+    @DisplayName("예산 데이터 일관성 및 동시성 테스트")
+    @Test
+    void budgetDataConsistencyTest() {
+        // given - 월별 예산과 여러 일일 예산 생성
+        YearMonth currentMonth = YearMonth.now();
+        MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(600000), currentMonth);
+        budgetRepository.save(monthlyBudget);
+
+        LocalDate startDate = currentMonth.atDay(1);
+        for (int i = 0; i < 10; i++) {
+            LocalDate date = startDate.plusDays(i);
+            DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(20000), date);
+            budgetRepository.save(dailyBudget);
+        }
+
+        // when - 동시에 여러 예산에 지출 추가
+        monthlyBudget.addSpent(100000);
+        
+        List<DailyBudget> dailyBudgets = budgetRepository.findDailyBudgetsViaType(memberProfile.getId());
+        for (int i = 0; i < dailyBudgets.size(); i++) {
+            dailyBudgets.get(i).addSpent(10000 + i * 1000);
+        }
+
+        // 모든 변경사항 저장
+        budgetRepository.save(monthlyBudget);
+        budgetRepository.saveAll(dailyBudgets);
+
+        // then - 데이터 일관성 확인
+        MonthlyBudget retrievedMonthly = budgetService.getMonthlyBudgetBy(memberProfile.getId(), currentMonth);
+        assertThat(retrievedMonthly.getSpendAmount()).isEqualTo(BigDecimal.valueOf(100000));
+
+        List<DailyBudget> retrievedDailies = budgetRepository.findDailyBudgetsViaType(memberProfile.getId());
+        for (int i = 0; i < retrievedDailies.size(); i++) {
+            assertThat(retrievedDailies.get(i).getSpendAmount())
+                    .isEqualTo(BigDecimal.valueOf(10000 + i * 1000));
+        }
+
+        // 총 일일 지출과 월별 지출의 독립성 확인
+        BigDecimal totalDailySpent = retrievedDailies.stream()
+                .map(DailyBudget::getSpendAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        
+        // 월별 예산과 일일 예산의 지출은 독립적으로 관리됨
+        assertThat(retrievedMonthly.getSpendAmount()).isNotEqualTo(totalDailySpent);
+    }
+} 

--- a/src/test/java/com/stcom/smartmealtable/repository/BudgetRepositoryAdvancedTest.java
+++ b/src/test/java/com/stcom/smartmealtable/repository/BudgetRepositoryAdvancedTest.java
@@ -1,0 +1,398 @@
+package com.stcom.smartmealtable.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.stcom.smartmealtable.domain.Budget.DailyBudget;
+import com.stcom.smartmealtable.domain.Budget.MonthlyBudget;
+import com.stcom.smartmealtable.domain.member.Member;
+import com.stcom.smartmealtable.domain.member.MemberProfile;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class BudgetRepositoryAdvancedTest {
+
+    @Autowired
+    private BudgetRepository budgetRepository;
+
+    @Autowired
+    private MemberProfileRepository memberProfileRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member1, member2;
+    private MemberProfile profile1, profile2;
+
+    @BeforeEach
+    void setUp() {
+        // 첫 번째 멤버 및 프로필
+        member1 = Member.builder()
+                .email("user1@test.com")
+                .rawPassword("password123!")
+                .build();
+        memberRepository.save(member1);
+
+        profile1 = MemberProfile.builder()
+                .nickName("user1")
+                .member(member1)
+                .build();
+        memberProfileRepository.save(profile1);
+
+        // 두 번째 멤버 및 프로필
+        member2 = Member.builder()
+                .email("user2@test.com")
+                .rawPassword("password123!")
+                .build();
+        memberRepository.save(member2);
+
+        profile2 = MemberProfile.builder()
+                .nickName("user2")
+                .member(member2)
+                .build();
+        memberProfileRepository.save(profile2);
+    }
+
+    @DisplayName("타입별 예산 조회 쿼리가 올바르게 동작한다")
+    @Test
+    void findBudgetsByTypeQueryTest() {
+        // given - 다양한 타입의 예산 생성
+        LocalDate today = LocalDate.now();
+        YearMonth currentMonth = YearMonth.now();
+
+        // 일일 예산들
+        for (int i = 0; i < 5; i++) {
+            DailyBudget dailyBudget = new DailyBudget(profile1, BigDecimal.valueOf(20000 + i * 1000), today.plusDays(i));
+            budgetRepository.save(dailyBudget);
+        }
+
+        // 월별 예산들
+        for (int i = 0; i < 3; i++) {
+            MonthlyBudget monthlyBudget = new MonthlyBudget(profile1, BigDecimal.valueOf(500000 + i * 100000), currentMonth.plusMonths(i));
+            budgetRepository.save(monthlyBudget);
+        }
+
+        // 다른 사용자의 예산들 (격리 테스트용)
+        DailyBudget otherUserDaily = new DailyBudget(profile2, BigDecimal.valueOf(30000), today);
+        budgetRepository.save(otherUserDaily);
+
+        // when
+        List<DailyBudget> dailyBudgets = budgetRepository.findDailyBudgetsViaType(profile1.getId());
+        List<MonthlyBudget> monthlyBudgets = budgetRepository.findMonthlyBudgetsViaType(profile1.getId());
+
+        // then
+        assertThat(dailyBudgets).hasSize(5);
+        assertThat(monthlyBudgets).hasSize(3);
+
+        // 타입 검증
+        for (DailyBudget budget : dailyBudgets) {
+            assertThat(budget).isInstanceOf(DailyBudget.class);
+            assertThat(budget.getMemberProfile().getId()).isEqualTo(profile1.getId());
+        }
+
+        for (MonthlyBudget budget : monthlyBudgets) {
+            assertThat(budget).isInstanceOf(MonthlyBudget.class);
+            assertThat(budget.getMemberProfile().getId()).isEqualTo(profile1.getId());
+        }
+    }
+
+    @DisplayName("최신 예산 조회 쿼리가 올바르게 정렬하여 조회한다")
+    @Test
+    void findFirstBudgetOrderingTest() {
+        // given - 고유한 프로필로 테스트
+        Member testMember = Member.builder()
+                .email("ordering@test.com")
+                .rawPassword("password123!")
+                .build();
+        memberRepository.save(testMember);
+
+        MemberProfile testProfile = MemberProfile.builder()
+                .nickName("orderingTestUser")
+                .member(testMember)
+                .build();
+        memberProfileRepository.save(testProfile);
+
+        // 날짜 순서가 뒤섞인 예산들 생성
+        LocalDate baseDate = LocalDate.of(2025, 8, 15);
+        YearMonth baseMonth = YearMonth.of(2025, 8);
+
+        // 일일 예산들 (날짜 순서 뒤섞어서 생성)
+        DailyBudget dailyBudget1 = new DailyBudget(testProfile, BigDecimal.valueOf(20000), baseDate.plusDays(5));
+        DailyBudget dailyBudget2 = new DailyBudget(testProfile, BigDecimal.valueOf(25000), baseDate.plusDays(2));
+        DailyBudget dailyBudget3 = new DailyBudget(testProfile, BigDecimal.valueOf(30000), baseDate.plusDays(10)); // 가장 최신
+
+        budgetRepository.save(dailyBudget1);
+        budgetRepository.save(dailyBudget2);
+        budgetRepository.save(dailyBudget3);
+
+        // 월별 예산들 - 각각 다른 년월로 생성
+        MonthlyBudget monthlyBudget1 = new MonthlyBudget(testProfile, BigDecimal.valueOf(500000), baseMonth.plusMonths(1));
+        MonthlyBudget monthlyBudget2 = new MonthlyBudget(testProfile, BigDecimal.valueOf(600000), baseMonth.plusMonths(3)); // 가장 최신
+        MonthlyBudget monthlyBudget3 = new MonthlyBudget(testProfile, BigDecimal.valueOf(550000), baseMonth.plusMonths(2));
+
+        budgetRepository.save(monthlyBudget1);
+        budgetRepository.save(monthlyBudget2);
+        budgetRepository.save(monthlyBudget3);
+
+        // when
+        Optional<DailyBudget> latestDaily = budgetRepository.findFirstDailyBudgetByMemberProfileId(testProfile.getId());
+        Optional<MonthlyBudget> latestMonthly = budgetRepository.findFirstMonthlyBudgetByMemberProfileId(testProfile.getId());
+
+        // then - 가장 최신 날짜/년월의 예산이 조회되어야 함
+        assertThat(latestDaily).isPresent();
+        assertThat(latestDaily.get().getDate()).isEqualTo(baseDate.plusDays(10));
+        assertThat(latestDaily.get().getLimit()).isEqualTo(BigDecimal.valueOf(30000));
+
+        assertThat(latestMonthly).isPresent();
+        assertThat(latestMonthly.get().getYearMonth()).isEqualTo(baseMonth.plusMonths(3));
+        assertThat(latestMonthly.get().getLimit()).isEqualTo(BigDecimal.valueOf(600000));
+    }
+
+    @DisplayName("날짜 범위 조회 쿼리가 정확한 경계값으로 동작한다")
+    @Test
+    void findBudgetsByDateRangeBoundaryTest() {
+        // given - 다양한 날짜의 일일 예산 생성
+        LocalDate baseDate = LocalDate.of(2025, 6, 15);
+        
+        for (int i = -5; i <= 5; i++) {
+            LocalDate date = baseDate.plusDays(i);
+            DailyBudget budget = new DailyBudget(profile1, BigDecimal.valueOf(10000 + Math.abs(i) * 1000), date);
+            budgetRepository.save(budget);
+        }
+
+        // when - 정확한 범위로 조회
+        LocalDate startDate = baseDate.minusDays(2); // 6월 13일
+        LocalDate endDate = baseDate.plusDays(2);    // 6월 17일
+        
+        List<DailyBudget> budgetsInRange = budgetRepository.findDailyBudgetsByMemberProfileIdAndDateBetween(
+                profile1.getId(), startDate, endDate);
+
+        // then - 경계값 포함하여 5개 조회되어야 함
+        assertThat(budgetsInRange).hasSize(5);
+        
+        for (DailyBudget budget : budgetsInRange) {
+            assertThat(budget.getDate()).isBetween(startDate, endDate);
+        }
+
+        // 경계값 테스트
+        assertThat(budgetsInRange.stream()
+                .anyMatch(b -> b.getDate().equals(startDate))).isTrue();
+        assertThat(budgetsInRange.stream()
+                .anyMatch(b -> b.getDate().equals(endDate))).isTrue();
+    }
+
+    @DisplayName("프로필별 예산 격리가 올바르게 동작한다")
+    @Test
+    void budgetIsolationByProfileTest() {
+        // given - 같은 날짜에 두 프로필의 예산 생성
+        LocalDate sameDate = LocalDate.now();
+        YearMonth sameMonth = YearMonth.now();
+
+        // 프로필1의 예산들
+        DailyBudget daily1 = new DailyBudget(profile1, BigDecimal.valueOf(20000), sameDate);
+        MonthlyBudget monthly1 = new MonthlyBudget(profile1, BigDecimal.valueOf(500000), sameMonth);
+        budgetRepository.save(daily1);
+        budgetRepository.save(monthly1);
+
+        // 프로필2의 예산들
+        DailyBudget daily2 = new DailyBudget(profile2, BigDecimal.valueOf(30000), sameDate);
+        MonthlyBudget monthly2 = new MonthlyBudget(profile2, BigDecimal.valueOf(600000), sameMonth);
+        budgetRepository.save(daily2);
+        budgetRepository.save(monthly2);
+
+        // when
+        Optional<DailyBudget> profile1Daily = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(profile1.getId(), sameDate);
+        Optional<DailyBudget> profile2Daily = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(profile2.getId(), sameDate);
+        
+        Optional<MonthlyBudget> profile1Monthly = budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(profile1.getId(), sameMonth);
+        Optional<MonthlyBudget> profile2Monthly = budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(profile2.getId(), sameMonth);
+
+        // then - 각 프로필별로 올바른 예산이 조회되어야 함
+        assertThat(profile1Daily).isPresent();
+        assertThat(profile1Daily.get().getLimit()).isEqualTo(BigDecimal.valueOf(20000));
+
+        assertThat(profile2Daily).isPresent();
+        assertThat(profile2Daily.get().getLimit()).isEqualTo(BigDecimal.valueOf(30000));
+
+        assertThat(profile1Monthly).isPresent();
+        assertThat(profile1Monthly.get().getLimit()).isEqualTo(BigDecimal.valueOf(500000));
+
+        assertThat(profile2Monthly).isPresent();
+        assertThat(profile2Monthly.get().getLimit()).isEqualTo(BigDecimal.valueOf(600000));
+
+        // 서로 다른 객체여야 함
+        assertThat(profile1Daily.get().getId()).isNotEqualTo(profile2Daily.get().getId());
+        assertThat(profile1Monthly.get().getId()).isNotEqualTo(profile2Monthly.get().getId());
+    }
+
+    @DisplayName("대량 데이터에서의 쿼리 성능 및 정확성 테스트")
+    @Test
+    void largeDataQueryPerformanceTest() {
+        // given - 고유한 프로필로 테스트
+        Member performanceMember = Member.builder()
+                .email("performance@test.com")
+                .rawPassword("password123!")
+                .build();
+        memberRepository.save(performanceMember);
+
+        MemberProfile performanceProfile = MemberProfile.builder()
+                .nickName("performanceTestUser")
+                .member(performanceMember)
+                .build();
+        memberProfileRepository.save(performanceProfile);
+
+        // 대량의 일일 예산 데이터 생성 (서로 다른 날짜)
+        LocalDate startDate = LocalDate.of(2024, 1, 1); // 2024년 데이터로 변경
+        
+        for (int i = 0; i < 365; i++) { // 1년치 데이터
+            LocalDate date = startDate.plusDays(i);
+            DailyBudget budget = new DailyBudget(performanceProfile, BigDecimal.valueOf(20000 + i), date);
+            budgetRepository.save(budget);
+        }
+
+        // when - 다양한 쿼리 실행
+        long startTime = System.currentTimeMillis();
+        
+        List<DailyBudget> allDailyBudgets = budgetRepository.findDailyBudgetsViaType(performanceProfile.getId());
+        Optional<DailyBudget> latestBudget = budgetRepository.findFirstDailyBudgetByMemberProfileId(performanceProfile.getId());
+        
+        // 1개월 범위 조회
+        LocalDate monthStart = LocalDate.of(2024, 6, 1);
+        LocalDate monthEnd = LocalDate.of(2024, 6, 30);
+        List<DailyBudget> monthlyData = budgetRepository.findDailyBudgetsByMemberProfileIdAndDateBetween(
+                performanceProfile.getId(), monthStart, monthEnd);
+        
+        long endTime = System.currentTimeMillis();
+        long executionTime = endTime - startTime;
+
+        // then - 성능 및 정확성 검증
+        assertThat(allDailyBudgets).hasSize(365);
+        assertThat(latestBudget).isPresent();
+        assertThat(latestBudget.get().getDate()).isEqualTo(startDate.plusDays(364)); // 2024년 12월 31일
+        
+        assertThat(monthlyData).hasSize(30); // 6월은 30일
+        assertThat(executionTime).isLessThan(5000); // 5초 이내 실행
+
+        // 데이터 정확성 검증
+        for (DailyBudget budget : monthlyData) {
+            assertThat(budget.getDate().getMonth().getValue()).isEqualTo(6);
+            assertThat(budget.getDate().getYear()).isEqualTo(2024);
+        }
+    }
+
+    @DisplayName("복합 조건 쿼리 및 정렬 테스트")
+    @Test
+    void complexQueryAndSortingTest() {
+        // given - 고유한 프로필로 테스트
+        Member complexMember = Member.builder()
+                .email("complex@test.com")
+                .rawPassword("password123!")
+                .build();
+        memberRepository.save(complexMember);
+
+        MemberProfile complexProfile = MemberProfile.builder()
+                .nickName("complexTestUser")
+                .member(complexMember)
+                .build();
+        memberProfileRepository.save(complexProfile);
+
+        // 복잡한 시나리오의 데이터 생성
+        LocalDate testDate = LocalDate.of(2025, 7, 1);  // 고정된 날짜 사용
+        YearMonth testMonth = YearMonth.of(2025, 7);
+
+        // 한 주간의 일일 예산들 (월요일~일요일) - 각기 다른 날짜
+        LocalDate monday = testDate.with(java.time.DayOfWeek.MONDAY);
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = monday.plusDays(i);
+            BigDecimal limit = BigDecimal.valueOf(15000 + i * 2000); // 점진적 증가
+            DailyBudget budget = new DailyBudget(complexProfile, limit, date);
+            budget.addSpent(5000 + i * 1000); // 지출도 점진적 증가
+            budgetRepository.save(budget);
+        }
+
+        // 여러 월의 월별 예산들 - 각기 다른 년월
+        for (int i = 0; i < 6; i++) {
+            YearMonth month = testMonth.plusMonths(i); // 미래 월로 변경하여 충돌 방지
+            MonthlyBudget budget = new MonthlyBudget(complexProfile, BigDecimal.valueOf(400000 + i * 50000), month);
+            budget.addSpent(200000 + i * 30000);
+            budgetRepository.save(budget);
+        }
+
+        // when
+        List<DailyBudget> weeklyBudgets = budgetRepository.findDailyBudgetsByMemberProfileIdAndDateBetween(
+                complexProfile.getId(), monday, monday.plusDays(6));
+        
+        Optional<DailyBudget> latestDaily = budgetRepository.findFirstDailyBudgetByMemberProfileId(complexProfile.getId());
+        Optional<MonthlyBudget> latestMonthly = budgetRepository.findFirstMonthlyBudgetByMemberProfileId(complexProfile.getId());
+
+        // then - 정렬 및 데이터 검증
+        assertThat(weeklyBudgets).hasSize(7);
+        
+        // 날짜 순 정렬 확인 (쿼리에서 정렬하지 않으므로 ID 순으로 조회됨)
+        for (int i = 0; i < weeklyBudgets.size() - 1; i++) {
+            DailyBudget current = weeklyBudgets.get(i);
+            DailyBudget next = weeklyBudgets.get(i + 1);
+            // 생성 순서 확인 (ID가 증가하는 순서)
+            assertThat(current.getId()).isLessThan(next.getId());
+        }
+
+        // 최신 예산 검증
+        assertThat(latestDaily).isPresent();
+        assertThat(latestDaily.get().getDate()).isEqualTo(monday.plusDays(6)); // 일요일
+
+        assertThat(latestMonthly).isPresent();
+        assertThat(latestMonthly.get().getYearMonth()).isEqualTo(testMonth.plusMonths(5)); // 가장 미래 월
+
+        // 지출 금액 검증
+        for (int i = 0; i < weeklyBudgets.size(); i++) {
+            DailyBudget budget = weeklyBudgets.get(i);
+            BigDecimal expectedSpent = BigDecimal.valueOf(5000 + i * 1000);
+            assertThat(budget.getSpendAmount()).isEqualTo(expectedSpent);
+        }
+    }
+
+    @DisplayName("null 값 및 edge case 처리 테스트")
+    @Test
+    void nullValueAndEdgeCaseTest() {
+        // given - 존재하지 않는 데이터 조회 시나리오
+
+        // when - 존재하지 않는 프로필 ID로 조회
+        Long nonExistentProfileId = 999999L;
+        List<DailyBudget> emptyDailyList = budgetRepository.findDailyBudgetsViaType(nonExistentProfileId);
+        List<MonthlyBudget> emptyMonthlyList = budgetRepository.findMonthlyBudgetsViaType(nonExistentProfileId);
+        
+        Optional<DailyBudget> emptyDailyOpt = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(
+                nonExistentProfileId, LocalDate.now());
+        Optional<MonthlyBudget> emptyMonthlyOpt = budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(
+                nonExistentProfileId, YearMonth.now());
+
+        // then - 빈 결과 반환
+        assertThat(emptyDailyList).isEmpty();
+        assertThat(emptyMonthlyList).isEmpty();
+        assertThat(emptyDailyOpt).isEmpty();
+        assertThat(emptyMonthlyOpt).isEmpty();
+
+        // when - 존재하지 않는 날짜로 조회
+        LocalDate futureDate = LocalDate.of(2030, 12, 31);
+        YearMonth futureMonth = YearMonth.of(2030, 12);
+        
+        Optional<DailyBudget> futureDailyOpt = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(
+                profile1.getId(), futureDate);
+        Optional<MonthlyBudget> futureMonthlyOpt = budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(
+                profile1.getId(), futureMonth);
+
+        // then - 빈 결과 반환
+        assertThat(futureDailyOpt).isEmpty();
+        assertThat(futureMonthlyOpt).isEmpty();
+    }
+} 

--- a/src/test/java/com/stcom/smartmealtable/repository/BudgetRepositoryTest.java
+++ b/src/test/java/com/stcom/smartmealtable/repository/BudgetRepositoryTest.java
@@ -1,0 +1,164 @@
+package com.stcom.smartmealtable.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.stcom.smartmealtable.domain.Budget.DailyBudget;
+import com.stcom.smartmealtable.domain.Budget.MonthlyBudget;
+import com.stcom.smartmealtable.domain.member.Member;
+import com.stcom.smartmealtable.domain.member.MemberProfile;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class BudgetRepositoryTest {
+
+    @Autowired
+    private BudgetRepository budgetRepository;
+
+    @Autowired
+    private MemberProfileRepository memberProfileRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("프로필 ID와 일자 정보로 일일 예산을 조회한다.")
+    @Test
+    void findDailyBudgetByMemberProfileIdAndDate() throws Exception {
+        // given
+        Member member = Member.builder()
+                .email("abcd@naver.com")
+                .rawPassword("@absdv123")
+                .build();
+
+        memberRepository.save(member);
+
+        MemberProfile memberProfile = MemberProfile.builder()
+                .nickName("testUser")
+                .member(member)
+                .build();
+        memberProfileRepository.save(memberProfile);
+
+        DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(1000), LocalDate.now());
+        budgetRepository.save(dailyBudget);
+
+        // when
+        DailyBudget foundBudget = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(
+                        memberProfile.getId(), LocalDate.now())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예산입니다"));
+
+        // then
+        assertThat(foundBudget).isNotNull();
+        assertThat(foundBudget.getMemberProfile()).isEqualTo(memberProfile);
+        assertThat(foundBudget.getLimit()).isEqualByComparingTo(BigDecimal.valueOf(1000));
+        assertThat(foundBudget.getDate()).isEqualTo(LocalDate.now());
+        assertThat(foundBudget.getId()).isNotNull();
+    }
+
+    @DisplayName("존재하지 않는 프로필 ID와 일자 정보로 일일 예산을 조회하면 빈 Optional을 반환한다.")
+    @Test
+    void findDailyBudgetByMemberProfileIdAndDate2() throws Exception {
+        // given
+        Member member = Member.builder()
+                .email("abcd@naver.com")
+                .rawPassword("@absdv123")
+                .build();
+
+        memberRepository.save(member);
+
+        MemberProfile memberProfile = MemberProfile.builder()
+                .nickName("testUser")
+                .member(member)
+                .build();
+        memberProfileRepository.save(memberProfile);
+
+        LocalDate date = LocalDate.now();
+        DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(1000), date);
+        budgetRepository.save(dailyBudget);
+
+        // when
+        // 존재하지 않는 프로필 ID와 일자 정보로 조회
+        Long nonExistentProfileId = 999L;
+        var foundBudget = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(nonExistentProfileId, date);
+
+        // then
+        assertThat(foundBudget).isEmpty();
+    }
+
+    @DisplayName("프로필 ID와 년월 정보로 월별 예산을 조회한다")
+    @Test
+    void findMonthlyBudgetByMemberProfileIdAndYearMonth() throws Exception {
+        // given
+        // given
+        Member member = Member.builder()
+                .email("abcd@naver.com")
+                .rawPassword("@absdv123")
+                .build();
+
+        memberRepository.save(member);
+
+        MemberProfile memberProfile = MemberProfile.builder()
+                .nickName("testUser")
+                .member(member)
+                .build();
+        memberProfileRepository.save(memberProfile);
+
+        YearMonth yearMonth = YearMonth.now();
+        MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(3000), yearMonth);
+        budgetRepository.save(monthlyBudget);
+
+        // when
+        MonthlyBudget foundBudget = budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(
+                        memberProfile.getId(), yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예산입니다"));
+
+        // then
+        assertThat(foundBudget).isNotNull();
+
+    }
+
+    @DisplayName("주어진 날짜 기간의 예산 정보를 조회한다")
+    @Test
+    void findDailyBudgetsByMemberProfileIdAndDateBetween() throws Exception {
+        // given
+        Member member = Member.builder()
+                .email("abcd@naver.com")
+                .rawPassword("@absdv123")
+                .build();
+
+        memberRepository.save(member);
+
+        MemberProfile memberProfile = MemberProfile.builder()
+                .nickName("testUser")
+                .member(member)
+                .build();
+        memberProfileRepository.save(memberProfile);
+
+        // when
+        LocalDate today = LocalDate.now();
+        LocalDate startOfWeek = today.minusDays(3); // 3일 전
+        LocalDate endOfWeek = today.plusDays(3); // 3일 후
+
+        // 예시로 5일의 일일 예산을 생성
+        for (int i = 0; i < 5; i++) {
+            LocalDate date = today.minusDays(i);
+            DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(1000 + i * 100), date);
+            budgetRepository.save(dailyBudget);
+        }
+
+        // 주어진 날짜 범위 내의 일일 예산을 조회
+        var dailyBudgets = budgetRepository.findDailyBudgetsByMemberProfileIdAndDateBetween(
+                memberProfile.getId(), startOfWeek, endOfWeek);
+
+        // then
+        assertThat(dailyBudgets).isNotEmpty();
+        assertThat(dailyBudgets.size()).isEqualTo(4);
+
+    }
+}

--- a/src/test/java/com/stcom/smartmealtable/service/BudgetServiceIntegrationTest.java
+++ b/src/test/java/com/stcom/smartmealtable/service/BudgetServiceIntegrationTest.java
@@ -128,7 +128,7 @@ class BudgetServiceIntegrationTest {
     void getDailyBudgetsByWeek() {
         // given
         LocalDate monday = LocalDate.of(2025, 6, 9); // 월요일
-        
+
         // 월요일부터 일요일까지 일일 예산 생성
         for (int i = 0; i < 7; i++) {
             LocalDate date = monday.plusDays(i);
@@ -152,7 +152,7 @@ class BudgetServiceIntegrationTest {
         // given
         Long dailyLimit = 25000L;
         LocalDate startDate = LocalDate.of(2025, 6, 15); // 6월 15일부터
-        
+
         // when
         budgetService.registerDefaultDailyBudgetBy(memberProfile.getId(), dailyLimit, startDate);
 
@@ -160,7 +160,7 @@ class BudgetServiceIntegrationTest {
         // 6월 15일부터 6월 30일까지 16개의 일일 예산이 생성되어야 함
         List<DailyBudget> dailyBudgets = budgetRepository.findDailyBudgetsViaType(memberProfile.getId());
         assertThat(dailyBudgets).hasSize(16);
-        
+
         for (DailyBudget budget : dailyBudgets) {
             assertThat(budget.getLimit()).isEqualTo(BigDecimal.valueOf(dailyLimit));
             assertThat(budget.getDate()).isBetween(startDate, LocalDate.of(2025, 6, 30));
@@ -190,7 +190,7 @@ class BudgetServiceIntegrationTest {
         LocalDate targetDate = LocalDate.of(2025, 6, 20);
         DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(20000), targetDate);
         budgetRepository.save(dailyBudget);
-        
+
         Long newLimit = 35000L;
 
         // when
@@ -208,7 +208,7 @@ class BudgetServiceIntegrationTest {
         YearMonth targetYearMonth = YearMonth.of(2025, 8);
         MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(600000), targetYearMonth);
         budgetRepository.save(monthlyBudget);
-        
+
         Long newLimit = 750000L;
 
         // when
@@ -229,7 +229,7 @@ class BudgetServiceIntegrationTest {
         // when & then
         assertThatThrownBy(() -> budgetService.getDailyBudgetBy(invalidProfileId, targetDate))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("존재하지 않는 프로필로 접근");
+                .hasMessage("예산이 존재하지 않습니다.");
     }
 
     @DisplayName("존재하지 않는 날짜의 예산을 조회하면 예외가 발생한다")
@@ -241,7 +241,7 @@ class BudgetServiceIntegrationTest {
         // when & then
         assertThatThrownBy(() -> budgetService.getDailyBudgetBy(memberProfile.getId(), nonExistentDate))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("존재하지 않는 프로필로 접근");
+                .hasMessage("예산이 존재하지 않습니다.");
     }
 
     @DisplayName("존재하지 않는 프로필 ID로 예산을 등록하면 예외가 발생한다")

--- a/src/test/java/com/stcom/smartmealtable/service/BudgetServiceIntegrationTest.java
+++ b/src/test/java/com/stcom/smartmealtable/service/BudgetServiceIntegrationTest.java
@@ -1,0 +1,259 @@
+package com.stcom.smartmealtable.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.stcom.smartmealtable.domain.Budget.DailyBudget;
+import com.stcom.smartmealtable.domain.Budget.MonthlyBudget;
+import com.stcom.smartmealtable.domain.member.Member;
+import com.stcom.smartmealtable.domain.member.MemberProfile;
+import com.stcom.smartmealtable.repository.BudgetRepository;
+import com.stcom.smartmealtable.repository.MemberProfileRepository;
+import com.stcom.smartmealtable.repository.MemberRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class BudgetServiceIntegrationTest {
+
+    @Autowired
+    private BudgetService budgetService;
+
+    @Autowired
+    private BudgetRepository budgetRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MemberProfileRepository memberProfileRepository;
+
+    private Member member;
+    private MemberProfile memberProfile;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("test@example.com")
+                .rawPassword("password123!")
+                .build();
+        memberRepository.save(member);
+
+        memberProfile = MemberProfile.builder()
+                .nickName("testUser")
+                .member(member)
+                .build();
+        memberProfileRepository.save(memberProfile);
+    }
+
+    @DisplayName("일일 예산을 저장하고 조회할 수 있다")
+    @Test
+    void saveDailyBudgetCustom() {
+        // given
+        Long limit = 50000L;
+
+        // when
+        budgetService.saveDailyBudgetCustom(memberProfile.getId(), limit);
+
+        // then
+        DailyBudget savedBudget = budgetService.findRecentDailyBudgetByMemberProfileId(memberProfile.getId());
+        assertThat(savedBudget.getLimit()).isEqualTo(BigDecimal.valueOf(limit));
+        assertThat(savedBudget.getMemberProfile().getId()).isEqualTo(memberProfile.getId());
+        assertThat(savedBudget.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+    }
+
+    @DisplayName("월별 예산을 저장하고 조회할 수 있다")
+    @Test
+    void saveMonthlyBudgetCustom() {
+        // given
+        Long limit = 1000000L;
+
+        // when
+        budgetService.saveMonthlyBudgetCustom(memberProfile.getId(), limit);
+
+        // then
+        MonthlyBudget savedBudget = budgetService.findRecentMonthlyBudgetByMemberProfileId(memberProfile.getId());
+        assertThat(savedBudget.getLimit()).isEqualTo(BigDecimal.valueOf(limit));
+        assertThat(savedBudget.getMemberProfile().getId()).isEqualTo(memberProfile.getId());
+        assertThat(savedBudget.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+    }
+
+    @DisplayName("특정 날짜의 일일 예산을 조회할 수 있다")
+    @Test
+    void getDailyBudgetByDate() {
+        // given
+        LocalDate targetDate = LocalDate.of(2025, 6, 15);
+        DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(30000), targetDate);
+        budgetRepository.save(dailyBudget);
+
+        // when
+        DailyBudget foundBudget = budgetService.getDailyBudgetBy(memberProfile.getId(), targetDate);
+
+        // then
+        assertThat(foundBudget.getDate()).isEqualTo(targetDate);
+        assertThat(foundBudget.getLimit()).isEqualTo(BigDecimal.valueOf(30000));
+        assertThat(foundBudget.getMemberProfile().getId()).isEqualTo(memberProfile.getId());
+    }
+
+    @DisplayName("특정 년월의 월별 예산을 조회할 수 있다")
+    @Test
+    void getMonthlyBudgetByYearMonth() {
+        // given
+        YearMonth targetYearMonth = YearMonth.of(2025, 6);
+        MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(800000), targetYearMonth);
+        budgetRepository.save(monthlyBudget);
+
+        // when
+        MonthlyBudget foundBudget = budgetService.getMonthlyBudgetBy(memberProfile.getId(), targetYearMonth);
+
+        // then
+        assertThat(foundBudget.getYearMonth()).isEqualTo(targetYearMonth);
+        assertThat(foundBudget.getLimit()).isEqualTo(BigDecimal.valueOf(800000));
+        assertThat(foundBudget.getMemberProfile().getId()).isEqualTo(memberProfile.getId());
+    }
+
+    @DisplayName("한 주간의 일일 예산 목록을 조회할 수 있다")
+    @Test
+    void getDailyBudgetsByWeek() {
+        // given
+        LocalDate monday = LocalDate.of(2025, 6, 9); // 월요일
+        
+        // 월요일부터 일요일까지 일일 예산 생성
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = monday.plusDays(i);
+            DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(10000 + i * 1000), date);
+            budgetRepository.save(dailyBudget);
+        }
+
+        // when - 주 중 아무 날짜나 입력해도 해당 주의 예산을 조회
+        LocalDate wednesday = monday.plusDays(2);
+        List<DailyBudget> weeklyBudgets = budgetService.getDailyBudgetsByWeek(memberProfile.getId(), wednesday);
+
+        // then
+        assertThat(weeklyBudgets).hasSize(7);
+        assertThat(weeklyBudgets.get(0).getDate()).isEqualTo(monday);
+        assertThat(weeklyBudgets.get(6).getDate()).isEqualTo(monday.plusDays(6));
+    }
+
+    @DisplayName("디폴트 일일 예산을 등록하면 해당 월의 남은 일자에 대해 일일 예산이 생성된다")
+    @Test
+    void registerDefaultDailyBudget() {
+        // given
+        Long dailyLimit = 25000L;
+        LocalDate startDate = LocalDate.of(2025, 6, 15); // 6월 15일부터
+        
+        // when
+        budgetService.registerDefaultDailyBudgetBy(memberProfile.getId(), dailyLimit, startDate);
+
+        // then
+        // 6월 15일부터 6월 30일까지 16개의 일일 예산이 생성되어야 함
+        List<DailyBudget> dailyBudgets = budgetRepository.findDailyBudgetsViaType(memberProfile.getId());
+        assertThat(dailyBudgets).hasSize(16);
+        
+        for (DailyBudget budget : dailyBudgets) {
+            assertThat(budget.getLimit()).isEqualTo(BigDecimal.valueOf(dailyLimit));
+            assertThat(budget.getDate()).isBetween(startDate, LocalDate.of(2025, 6, 30));
+        }
+    }
+
+    @DisplayName("디폴트 월별 예산을 등록할 수 있다")
+    @Test
+    void registerDefaultMonthlyBudget() {
+        // given
+        Long monthlyLimit = 500000L;
+        YearMonth targetYearMonth = YearMonth.of(2025, 7);
+
+        // when
+        budgetService.registerDefaultMonthlyBudgetBy(memberProfile.getId(), monthlyLimit, targetYearMonth);
+
+        // then
+        MonthlyBudget savedBudget = budgetService.getMonthlyBudgetBy(memberProfile.getId(), targetYearMonth);
+        assertThat(savedBudget.getLimit()).isEqualTo(BigDecimal.valueOf(monthlyLimit));
+        assertThat(savedBudget.getYearMonth()).isEqualTo(targetYearMonth);
+    }
+
+    @DisplayName("일일 예산 한도를 수정할 수 있다")
+    @Test
+    void editDailyBudgetCustom() {
+        // given
+        LocalDate targetDate = LocalDate.of(2025, 6, 20);
+        DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(20000), targetDate);
+        budgetRepository.save(dailyBudget);
+        
+        Long newLimit = 35000L;
+
+        // when
+        budgetService.editDailyBudgetCustom(memberProfile.getId(), targetDate, newLimit);
+
+        // then
+        DailyBudget updatedBudget = budgetService.getDailyBudgetBy(memberProfile.getId(), targetDate);
+        assertThat(updatedBudget.getLimit()).isEqualTo(BigDecimal.valueOf(newLimit));
+    }
+
+    @DisplayName("월별 예산 한도를 수정할 수 있다")
+    @Test
+    void editMonthlyBudgetCustom() {
+        // given
+        YearMonth targetYearMonth = YearMonth.of(2025, 8);
+        MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(600000), targetYearMonth);
+        budgetRepository.save(monthlyBudget);
+        
+        Long newLimit = 750000L;
+
+        // when
+        budgetService.editMonthlyBudgetCustom(memberProfile.getId(), targetYearMonth, newLimit);
+
+        // then
+        MonthlyBudget updatedBudget = budgetService.getMonthlyBudgetBy(memberProfile.getId(), targetYearMonth);
+        assertThat(updatedBudget.getLimit()).isEqualTo(BigDecimal.valueOf(newLimit));
+    }
+
+    @DisplayName("존재하지 않는 프로필 ID로 예산을 조회하면 예외가 발생한다")
+    @Test
+    void getBudgetWithInvalidProfileId() {
+        // given
+        Long invalidProfileId = 999L;
+        LocalDate targetDate = LocalDate.now();
+
+        // when & then
+        assertThatThrownBy(() -> budgetService.getDailyBudgetBy(invalidProfileId, targetDate))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 프로필로 접근");
+    }
+
+    @DisplayName("존재하지 않는 날짜의 예산을 조회하면 예외가 발생한다")
+    @Test
+    void getBudgetWithInvalidDate() {
+        // given
+        LocalDate nonExistentDate = LocalDate.of(2030, 12, 31);
+
+        // when & then
+        assertThatThrownBy(() -> budgetService.getDailyBudgetBy(memberProfile.getId(), nonExistentDate))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 프로필로 접근");
+    }
+
+    @DisplayName("존재하지 않는 프로필 ID로 예산을 등록하면 예외가 발생한다")
+    @Test
+    void saveBudgetWithInvalidProfileId() {
+        // given
+        Long invalidProfileId = 999L;
+        Long limit = 50000L;
+
+        // when & then
+        assertThatThrownBy(() -> budgetService.saveDailyBudgetCustom(invalidProfileId, limit))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 프로필로 접근");
+    }
+} 

--- a/src/test/java/com/stcom/smartmealtable/service/BudgetServiceTest.java
+++ b/src/test/java/com/stcom/smartmealtable/service/BudgetServiceTest.java
@@ -41,9 +41,9 @@ class BudgetServiceTest {
         Long memberProfileId = 1L;
         MemberProfile memberProfile = new MemberProfile();
         DailyBudget dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(10000), LocalDate.now());
-        
+
         when(budgetRepository.findFirstDailyBudgetByMemberProfileId(memberProfileId))
-            .thenReturn(Optional.of(dailyBudget));
+                .thenReturn(Optional.of(dailyBudget));
 
         // when
         DailyBudget result = budgetService.findRecentDailyBudgetByMemberProfileId(memberProfileId);
@@ -58,14 +58,14 @@ class BudgetServiceTest {
     void findRecentDailyBudgetByMemberProfileId_NotFound() {
         // given
         Long memberProfileId = 999L;
-        
+
         when(budgetRepository.findFirstDailyBudgetByMemberProfileId(memberProfileId))
-            .thenReturn(Optional.empty());
+                .thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> budgetService.findRecentDailyBudgetByMemberProfileId(memberProfileId))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("존재하지 않는 프로필로 접근");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 프로필로 접근");
     }
 
     @Test
@@ -75,9 +75,9 @@ class BudgetServiceTest {
         Long memberProfileId = 1L;
         MemberProfile memberProfile = new MemberProfile();
         MonthlyBudget monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(300000), YearMonth.now());
-        
+
         when(budgetRepository.findFirstMonthlyBudgetByMemberProfileId(memberProfileId))
-            .thenReturn(Optional.of(monthlyBudget));
+                .thenReturn(Optional.of(monthlyBudget));
 
         // when
         MonthlyBudget result = budgetService.findRecentMonthlyBudgetByMemberProfileId(memberProfileId);
@@ -94,9 +94,9 @@ class BudgetServiceTest {
         Long memberProfileId = 1L;
         Long limit = 300000L;
         MemberProfile memberProfile = new MemberProfile();
-        
+
         when(memberProfileRepository.findById(memberProfileId))
-            .thenReturn(Optional.of(memberProfile));
+                .thenReturn(Optional.of(memberProfile));
 
         // when
         budgetService.saveMonthlyBudgetCustom(memberProfileId, limit);
@@ -112,9 +112,9 @@ class BudgetServiceTest {
         Long memberProfileId = 1L;
         Long limit = 10000L;
         MemberProfile memberProfile = new MemberProfile();
-        
+
         when(memberProfileRepository.findById(memberProfileId))
-            .thenReturn(Optional.of(memberProfile));
+                .thenReturn(Optional.of(memberProfile));
 
         // when
         budgetService.saveDailyBudgetCustom(memberProfileId, limit);
@@ -129,13 +129,14 @@ class BudgetServiceTest {
         // given
         Long memberProfileId = 999L;
         Long limit = 10000L;
-        
+
         when(memberProfileRepository.findById(memberProfileId))
-            .thenReturn(Optional.empty());
+                .thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> budgetService.saveDailyBudgetCustom(memberProfileId, limit))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("존재하지 않는 프로필로 접근");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 프로필로 접근");
     }
+    
 } 


### PR DESCRIPTION
1. 특정 기간 예산 설정 조회
2. 디폴트 예산 설정
3. 주간 예산 정보 조회


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 일별 및 월별 예산을 날짜 또는 연월 기준으로 조회할 수 있는 API가 추가되었습니다.
  - 일별/월별 예산의 한도를 등록 및 수정할 수 있는 API가 추가되었습니다.
  - 지정한 날짜가 포함된 주간의 일별 예산 목록을 조회할 수 있는 기능이 제공됩니다.
  - 연월 포맷을 지원하는 커스텀 날짜 포맷터 및 어노테이션이 도입되었습니다.

- **버그 수정**
  - 예산 조회 및 저장 시 존재하지 않는 프로필이나 예산에 대해 예외 메시지가 개선되었습니다.

- **테스트**
  - 예산 도메인, 서비스, 저장소의 동작을 검증하는 다양한 통합 및 단위 테스트가 추가되었습니다.
  - 대용량 데이터, 엣지 케이스, 다중 사용자 시나리오 등 다양한 상황에 대한 테스트가 포함되었습니다.

- **문서화**
  - API 응답 구조가 일별/월별 예산의 상세 정보를 포함하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->