### PR TITLE
feat: 결제 메시지 파싱 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
+ext {
+    springAiVersion = "1.0.0"
+}
+
 group = 'com.stcom'
 version = '0.0.1-SNAPSHOT'
 
@@ -33,6 +37,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+    implementation 'org.springframework.ai:spring-ai-bom:1.0.0'
+    implementation 'org.springframework.ai:spring-ai-starter-model-vertex-ai-gemini'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 직렬화/역직렬화에 Jackson 사용
     compileOnly 'org.projectlombok:lombok'
@@ -51,4 +57,10 @@ tasks.named('test') {
 
 jar {
     enabled = false
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.ai:spring-ai-bom:$springAiVersion"
+    }
 }

--- a/src/main/java/com/stcom/smartmealtable/component/creditmessage/CreditMessageManager.java
+++ b/src/main/java/com/stcom/smartmealtable/component/creditmessage/CreditMessageManager.java
@@ -1,0 +1,37 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreditMessageManager {
+
+    private final GeminiCreditMessageParser geminiParser;
+
+    private final Map<String, CreditMessageParser> parsers = Map.of(
+            "KB", new KBCreditMessageParser(),
+            "NH", new NHCreditMessageParser(),
+            "SH", new SHCreditMessageParser()
+    );
+
+    public ExpenditureDto parseMessage(String message) {
+        if (message == null || message.isEmpty()) {
+            throw new IllegalArgumentException("메시지가 비어 있습니다.");
+        }
+
+        for (CreditMessageParser parser : parsers.values()) {
+            if (parser.checkVendor(message)) {
+                try {
+                    return parser.parse(message);
+                } catch (Exception ignore) {
+                    // 룰 기반 파싱 실패 – Gemini 로 fallback
+                    break;
+                }
+            }
+        }
+
+        return geminiParser.parse(message);
+    }
+}

--- a/src/main/java/com/stcom/smartmealtable/component/creditmessage/CreditMessageParser.java
+++ b/src/main/java/com/stcom/smartmealtable/component/creditmessage/CreditMessageParser.java
@@ -1,0 +1,9 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+public interface CreditMessageParser {
+
+    boolean checkVendor(String message);
+
+    ExpenditureDto parse(String message);
+
+}

--- a/src/main/java/com/stcom/smartmealtable/component/creditmessage/ExpenditureDto.java
+++ b/src/main/java/com/stcom/smartmealtable/component/creditmessage/ExpenditureDto.java
@@ -1,0 +1,18 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+@ToString
+public class ExpenditureDto {
+
+    private String vendor;
+    private LocalDateTime dateTime;
+    private Long amount;
+    private String tradeName;
+
+}

--- a/src/main/java/com/stcom/smartmealtable/component/creditmessage/GeminiCreditMessageParser.java
+++ b/src/main/java/com/stcom/smartmealtable/component/creditmessage/GeminiCreditMessageParser.java
@@ -1,0 +1,61 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClient.Builder;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class GeminiCreditMessageParser implements CreditMessageParser {
+
+    private final Builder chatClientBuilder;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public boolean checkVendor(String message) {
+        return true;
+    }
+
+    @Override
+    public ExpenditureDto parse(String message) {
+        ChatClient chatClient = chatClientBuilder.build();
+
+        String prompt = String.format("""
+                너는 대한민국의 신용카드 승인 문자(SMS)를 파싱해서 JSON 형태로 반환하는 전문가야.
+                반드시 아래 형식의 JSON 만 출력해. 설명 문구나 코드 블록 표시(```)는 절대 포함하면 안 돼.
+                
+                {
+                  \"vendor\": \"<카드사 영문 약어, 예: KB, NH, SH, UNKNOWN>\",
+                  \"dateTime\": \"<ISO-8601 형식 yyyy-MM-dd'T'HH:mm:ss>\",
+                  \"amount\": <숫자형 원화 금액>,
+                  \"tradeName\": \"<가맹점명>\"
+                }
+                
+                다음은 파싱 대상 SMS 원문이다:
+                %s
+                """, message);
+
+        String jsonResponse = chatClient.prompt()
+                .user(prompt)
+                .call()
+                .content();
+        try {
+            JsonNode root = MAPPER.readTree(jsonResponse);
+            String vendor = root.path("vendor").asText("UNKNOWN");
+            String dateTimeStr = root.path("dateTime").asText();
+            long amount = root.path("amount").asLong();
+            String tradeName = root.path("tradeName").asText();
+
+            LocalDateTime dateTime = LocalDateTime.parse(dateTimeStr);
+            return new ExpenditureDto(vendor, dateTime, amount, tradeName);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Gemini 파싱 실패: " + e.getMessage(), e);
+        }
+    }
+} 

--- a/src/main/java/com/stcom/smartmealtable/component/creditmessage/KBCreditMessageParser.java
+++ b/src/main/java/com/stcom/smartmealtable/component/creditmessage/KBCreditMessageParser.java
@@ -1,0 +1,50 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class KBCreditMessageParser implements CreditMessageParser {
+
+    private static final Pattern KB_PATTERN = Pattern.compile(
+            // 1: MM/dd, 2: HH:mm, 3: amount, 4: trade name
+            "\\[KB국민카드]\\s*(\\d{2}/\\d{2})\\s*(\\d{2}:\\d{2})\\s*승인\\s*([\\d,]+)원\\s*[가-힣A-Za-z]*\\s*(.+)"
+    );
+
+    private static final DateTimeFormatter FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
+
+    @Override
+    public boolean checkVendor(String message) {
+        // 메시지에 "KB"가 포함되어 있는지 확인
+        return message != null && message.contains("KB");
+    }
+
+    @Override
+    public ExpenditureDto parse(String message) {
+        if (message == null) {
+            throw new IllegalArgumentException("메시지가 비어있습니다.");
+        }
+
+        Matcher matcher = KB_PATTERN.matcher(message);
+        if (!matcher.find()) {
+            throw new IllegalArgumentException("올바르지 않은 메시지 포맷입니다. " + message);
+        }
+
+        String datePart = matcher.group(1);
+        String timePart = matcher.group(2);
+        String amountPart = matcher.group(3).replace(",", ""); // “11,000” → “11000”
+        String tradeName = matcher.group(4).trim();
+
+        int currentYear = LocalDate.now().getYear();
+        LocalDateTime dateTime = LocalDateTime.parse(
+                currentYear + "/" + datePart + " " + timePart, FORMATTER
+        );
+
+        long amount = Long.parseLong(amountPart);
+
+        return new ExpenditureDto("KB", dateTime, amount, tradeName);
+    }
+}

--- a/src/main/java/com/stcom/smartmealtable/component/creditmessage/NHCreditMessageParser.java
+++ b/src/main/java/com/stcom/smartmealtable/component/creditmessage/NHCreditMessageParser.java
@@ -1,0 +1,43 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NHCreditMessageParser implements CreditMessageParser {
+
+    private static final Pattern NH_PATTERN = Pattern.compile(
+            "NH(?:농협)?카드.*?승인.*?([\\d,]+)원.*?(\\d{2}/\\d{2})\\s*(\\d{2}:\\d{2})\\s+(.+?)(?:\\s+(?:총누적|잔여).*)?$"
+    );
+
+    private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
+
+    @Override
+    public boolean checkVendor(String message) {
+        return message != null && (message.contains("NH") || message.contains("농협"));
+    }
+
+    @Override
+    public ExpenditureDto parse(String message) {
+        if (message == null) {
+            throw new IllegalArgumentException("메시지가 비어 있습니다.");
+        }
+
+        Matcher m = NH_PATTERN.matcher(message);
+        if (!m.find()) {
+            throw new IllegalArgumentException("농협카드 SMS 형식을 인식하지 못했습니다: " + message);
+        }
+
+        long amount = Long.parseLong(m.group(1).replace(",", ""));
+        int thisYear = LocalDate.now().getYear();
+        LocalDateTime dateTime = LocalDateTime.parse(
+                thisYear + "/" + m.group(2) + " " + m.group(3), FMT
+        );
+
+        String trade = m.group(4).trim();
+
+        return new ExpenditureDto("NH", dateTime, amount, trade);
+    }
+}

--- a/src/main/java/com/stcom/smartmealtable/component/creditmessage/SHCreditMessageParser.java
+++ b/src/main/java/com/stcom/smartmealtable/component/creditmessage/SHCreditMessageParser.java
@@ -1,0 +1,46 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SHCreditMessageParser implements CreditMessageParser {
+
+    private static final Pattern SH_PATTERN = Pattern.compile(
+            "신한카드.*?승인.*?([\\d,]+)원(?:\\([^)]*\\))?\\s*(\\d{2}/\\d{2})\\s*(\\d{2}:\\d{2})\\s+(.+?)(?:\\s+(?:누적|잔여).*)?$"
+    );
+
+    private static final DateTimeFormatter FMT =
+            DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
+
+    @Override
+    public boolean checkVendor(String message) {
+        return message != null && message.contains("신한카드");
+    }
+
+    @Override
+    public ExpenditureDto parse(String message) {
+        if (message == null) {
+            throw new IllegalArgumentException("메시지가 비어 있습니다.");
+        }
+
+        Matcher m = SH_PATTERN.matcher(message);
+        if (!m.find()) {
+            throw new IllegalArgumentException("신한카드 SMS 형식을 인식하지 못했습니다: " + message);
+        }
+
+        long amount = Long.parseLong(m.group(1).replace(",", ""));
+        int year = LocalDate.now().getYear();
+        LocalDateTime dateTime = LocalDateTime.parse(
+                year + "/" + m.group(2) + " " + m.group(3), FMT
+        );
+
+        String tradeName = m.group(4).trim()
+                .replaceAll("\\s*(누적|잔여|잔액).*", "") // 혹시 남은 잔여표기가 끼어들면 제거
+                .trim();
+
+        return new ExpenditureDto("SH", dateTime, amount, tradeName);
+    }
+}

--- a/src/test/java/com/stcom/smartmealtable/component/creditmessage/CreditMessageManagerTest.java
+++ b/src/test/java/com/stcom/smartmealtable/component/creditmessage/CreditMessageManagerTest.java
@@ -1,0 +1,72 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.ai.chat.client.ChatClient;
+
+class CreditMessageManagerTest {
+
+    private ChatClient.Builder builder;
+    private ChatClient chatClient;
+    private GeminiCreditMessageParser geminiParser;
+    private CreditMessageManager manager;
+
+    @BeforeEach
+    void setUp() {
+        // LLM 호출 모킹을 위한 deep stub
+        chatClient = mock(ChatClient.class, Mockito.RETURNS_DEEP_STUBS);
+        builder = mock(ChatClient.Builder.class);
+        when(builder.build()).thenReturn(chatClient);
+
+        geminiParser = spy(new GeminiCreditMessageParser(builder));
+        manager = new CreditMessageManager(geminiParser);
+    }
+
+    @Test
+    @DisplayName("KB 메시지는 룰 파서가 처리하고 Gemini 는 호출되지 않는다")
+    void ruleBasedParsingWorks() {
+        // given
+        String sms = "[KB국민카드] 06/12 10:20 승인 11,000원 스타벅스";
+
+        // when
+        ExpenditureDto dto = manager.parseMessage(sms);
+
+        // then
+        assertEquals("KB", dto.getVendor());
+        assertEquals(11000L, dto.getAmount());
+        verify(geminiParser, never()).parse(anyString());
+    }
+
+    @Test
+    @DisplayName("룰 파서 실패 시 Gemini fallback 이 동작한다")
+    void fallbackToGemini() {
+        // given
+        String llmJson = "{" +
+                "\"vendor\":\"UNKNOWN\"," +
+                "\"dateTime\":\"2025-06-12T10:20:00\"," +
+                "\"amount\":5000," +
+                "\"tradeName\":\"GS25\"}";
+
+        // when
+        when(chatClient.prompt().user(anyString()).call().content()).thenReturn(llmJson);
+
+        String sms = "알 수 없는 카드사 메시지";
+        ExpenditureDto dto = manager.parseMessage(sms);
+
+        // then
+        assertEquals("UNKNOWN", dto.getVendor());
+        assertEquals(5000L, dto.getAmount());
+        verify(geminiParser, times(1)).parse(anyString());
+    }
+} 

--- a/src/test/java/com/stcom/smartmealtable/component/creditmessage/GeminiCreditMessageParserTest.java
+++ b/src/test/java/com/stcom/smartmealtable/component/creditmessage/GeminiCreditMessageParserTest.java
@@ -1,0 +1,55 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.ai.chat.client.ChatClient;
+
+class GeminiCreditMessageParserTest {
+
+    private ChatClient.Builder builder;
+    private ChatClient chatClient;
+    private GeminiCreditMessageParser parser;
+
+    @BeforeEach
+    void setUp() {
+        // Deep-stub 으로 체이닝 메서드 mock
+        chatClient = mock(ChatClient.class, Mockito.RETURNS_DEEP_STUBS);
+        builder = mock(ChatClient.Builder.class);
+        when(builder.build()).thenReturn(chatClient);
+
+        parser = new GeminiCreditMessageParser(builder);
+    }
+
+    @Test
+    @DisplayName("LLM JSON 응답을 DTO 로 변환한다")
+    void parseSuccess() {
+        // given
+        String llmJson = "{" +
+                "\"vendor\":\"KB\"," +
+                "\"dateTime\":\"2025-06-12T10:20:00\"," +
+                "\"amount\":11000," +
+                "\"tradeName\":\"스타벅스\"}";
+
+        // when
+        when(chatClient.prompt().user(anyString()).call().content()).thenReturn(llmJson);
+
+        String sms = "[KB국민카드] 06/12 10:20 승인 11,000원 스타벅스";
+        ExpenditureDto dto = parser.parse(sms);
+
+        // then
+        assertAll(
+                () -> assertEquals("KB", dto.getVendor()),
+                () -> assertEquals(11000L, dto.getAmount()),
+                () -> assertEquals("스타벅스", dto.getTradeName()),
+                () -> assertEquals("2025-06-12T10:20", dto.getDateTime().toString().substring(0, 16))
+        );
+    }
+}

--- a/src/test/java/com/stcom/smartmealtable/component/creditmessage/KBCreditMessageParserTest.java
+++ b/src/test/java/com/stcom/smartmealtable/component/creditmessage/KBCreditMessageParserTest.java
@@ -1,0 +1,46 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KBCreditMessageParserTest {
+
+    KBCreditMessageParser parser = new KBCreditMessageParser();
+
+    @DisplayName("국민은행 결제 메시지인지 판별한다.")
+    @Test
+    void checkVendor() throws Exception {
+        // given
+        String kbMessage = "[KB국민카드] 07/16 12:28 승인 11,000원 일시불 롯데시네마 평촌";
+        // when & then
+        assertThat(parser.checkVendor(kbMessage)).isTrue();
+    }
+
+    @DisplayName("잘못된 벤더사의 메시지인지 확인한다.")
+    @Test
+    void checkVendor2() throws Exception {
+        // given
+        String illegalMessage = "[우리] 07/16 12:28 승인 11,000원 일시불 롯데시네마 평촌";
+        // when & then
+        assertThat(parser.checkVendor(illegalMessage)).isFalse();
+
+    }
+
+    @DisplayName("국민은행 결제 메시지를 파싱한다.")
+    @Test
+    void parse() throws Exception {
+        // given
+        String kbMessage = "[KB국민카드] 07/16 12:28 승인 11,000원 일시불 롯데시네마 평촌";
+        // when
+        ExpenditureDto expenditure = parser.parse(kbMessage);
+        // then
+        assertThat(expenditure.getVendor()).isEqualTo("KB");
+        assertThat(expenditure.getDateTime()).isEqualTo(LocalDateTime.of(LocalDateTime.now().getYear(), 7, 16, 12, 28));
+        assertThat(expenditure.getAmount()).isEqualTo(11000);
+        assertThat(expenditure.getTradeName()).isEqualTo("롯데시네마 평촌");
+
+    }
+}

--- a/src/test/java/com/stcom/smartmealtable/component/creditmessage/NHCreditMessageParserTest.java
+++ b/src/test/java/com/stcom/smartmealtable/component/creditmessage/NHCreditMessageParserTest.java
@@ -1,0 +1,47 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NHCreditMessageParserTest {
+
+    NHCreditMessageParser parser = new NHCreditMessageParser();
+
+    @DisplayName("농협 결제 메시지인지 판별한다.")
+    @Test
+    void checkVendor() throws Exception {
+        // given
+        String nhMessage = "NH카드595승인 가나다 5,700원 일시불 10/21 08:33 (주)티머니 개인택 총누적1,000,000원";
+        // when & then
+        assertThat(parser.checkVendor(nhMessage)).isTrue();
+    }
+
+    @DisplayName("잘못된 벤더사의 메시지인지 확인한다.")
+    @Test
+    void checkVendor2() throws Exception {
+        // given
+        String illegalMessage = "[우리] 07/16 12:28 승인 11,000원 일시불 롯데시네마 평촌";
+        // when & then
+        assertThat(parser.checkVendor(illegalMessage)).isFalse();
+
+    }
+
+    @DisplayName("농협 결제 메시지를 파싱한다.")
+    @Test
+    void parse() throws Exception {
+        // given
+        String nhMessage = "NH농협카드5*5승인 가나다 5,700원 일시불 10/21 08:33 (주)티머니 개인택 총누적1,000,000원";
+        // when
+        ExpenditureDto expenditure = parser.parse(nhMessage);
+        // then
+        assertThat(expenditure.getVendor()).isEqualTo("NH");
+        assertThat(expenditure.getDateTime()).isEqualTo(LocalDateTime.of(LocalDateTime.now().getYear(), 10, 21, 8, 33));
+        assertThat(expenditure.getAmount()).isEqualTo(5700);
+        assertThat(expenditure.getTradeName()).isEqualTo("(주)티머니 개인택");
+
+    }
+
+}

--- a/src/test/java/com/stcom/smartmealtable/component/creditmessage/SHCreditMessageParserTest.java
+++ b/src/test/java/com/stcom/smartmealtable/component/creditmessage/SHCreditMessageParserTest.java
@@ -1,0 +1,47 @@
+package com.stcom.smartmealtable.component.creditmessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SHCreditMessageParserTest {
+
+    SHCreditMessageParser parser = new SHCreditMessageParser();
+
+    @DisplayName("농협 결제 메시지인지 판별한다.")
+    @Test
+    void checkVendor() throws Exception {
+        // given
+        String shMessage = "신한카드(6193)승인 가나다 5,700원(일시불)10/21 08:33 (주)티머니 개인택 누적1,000,000원";
+        // when & then
+        assertThat(parser.checkVendor(shMessage)).isTrue();
+    }
+
+    @DisplayName("잘못된 벤더사의 메시지인지 확인한다.")
+    @Test
+    void checkVendor2() throws Exception {
+        // given
+        String illegalMessage = "[우리] 07/16 12:28 승인 11,000원 일시불 롯데시네마 평촌";
+        // when & then
+        assertThat(parser.checkVendor(illegalMessage)).isFalse();
+
+    }
+
+    @DisplayName("농협 결제 메시지를 파싱한다.")
+    @Test
+    void parse() throws Exception {
+        // given
+        String shMessage = "신한카드(6193)승인 가나다 5,700원(일시불)10/21 08:33 (주)티머니 개인택 누적1,000,000원";
+        // when
+        ExpenditureDto expenditure = parser.parse(shMessage);
+        // then
+        assertThat(expenditure.getVendor()).isEqualTo("SH");
+        assertThat(expenditure.getDateTime()).isEqualTo(LocalDateTime.of(LocalDateTime.now().getYear(), 10, 21, 8, 33));
+        assertThat(expenditure.getAmount()).isEqualTo(5700);
+        assertThat(expenditure.getTradeName()).isEqualTo("(주)티머니 개인택");
+
+    }
+
+}


### PR DESCRIPTION
1. 국민/농협/신한 결제 메시지 파싱 기능 추가
2. LLM 이용한 메시지 파싱 기능 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 다양한 카드사(KB국민, NH농협, 신한) 승인 문자에서 결제 정보를 자동으로 추출하는 기능이 추가되었습니다.
    - 카드사별 문자 형식이 인식되지 않을 경우, AI 기반 파서를 통해 결제 내역을 분석할 수 있습니다.

- **버그 수정**
    - 없음

- **테스트**
    - 카드사별 승인 문자 파싱 및 AI 파서 동작을 검증하는 테스트가 추가되었습니다.

- **기타**
    - Spring AI 관련 라이브러리 및 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->