### PR TITLE
feat: 지출내역 CRUD API 구현

### DIFF
--- a/src/main/java/com/stcom/smartmealtable/component/creditmessage/ExpenditureDto.java
+++ b/src/main/java/com/stcom/smartmealtable/component/creditmessage/ExpenditureDto.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 public class ExpenditureDto {
 
     private String vendor;
-    private LocalDateTime dateTime;
+    private LocalDateTime spentDate;
     private Long amount;
     private String tradeName;
 

--- a/src/main/java/com/stcom/smartmealtable/domain/Budget/Budget.java
+++ b/src/main/java/com/stcom/smartmealtable/domain/Budget/Budget.java
@@ -38,6 +38,7 @@ public abstract class Budget extends BaseTimeEntity {
     @Column(name = "budget_limit")
     private BigDecimal limit;
 
+
     protected Budget(MemberProfile memberProfile, BigDecimal limit) {
         this.memberProfile = memberProfile;
         this.limit = limit;
@@ -72,5 +73,9 @@ public abstract class Budget extends BaseTimeEntity {
             throw new IllegalArgumentException("예산 한도는 0 이상이어야 합니다.");
         }
         this.limit = limit;
+    }
+
+    public void subtractSpent(BigDecimal spent) {
+        this.spendAmount = this.spendAmount.subtract(spent);
     }
 }

--- a/src/main/java/com/stcom/smartmealtable/domain/Budget/DailyBudget.java
+++ b/src/main/java/com/stcom/smartmealtable/domain/Budget/DailyBudget.java
@@ -21,4 +21,5 @@ public class DailyBudget extends Budget {
 
     @Column(name = "daily_budget_date")
     private LocalDate date;
+    
 }

--- a/src/main/java/com/stcom/smartmealtable/domain/Budget/Expenditure.java
+++ b/src/main/java/com/stcom/smartmealtable/domain/Budget/Expenditure.java
@@ -1,0 +1,72 @@
+package com.stcom.smartmealtable.domain.Budget;
+
+import com.stcom.smartmealtable.domain.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Expenditure extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "expenditure_id")
+    private Long id;
+
+    private LocalDateTime spentDate;
+
+    private Long amount;
+
+    private String tradeName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_budget_id")
+    private DailyBudget dailyBudget;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "monthly_budget_id")
+    private MonthlyBudget monthlyBudget;
+
+
+    @Builder
+    public Expenditure(LocalDateTime spentDate, Long amount, String tradeName, DailyBudget dailyBudget,
+                       MonthlyBudget monthlyBudget) {
+        this.spentDate = spentDate;
+        this.amount = amount;
+        this.tradeName = tradeName;
+        this.dailyBudget = dailyBudget;
+        this.monthlyBudget = monthlyBudget;
+    }
+
+    private void updateSpentDate(LocalDateTime spentDate) {
+        this.spentDate = spentDate;
+    }
+
+    private void updateAmount(Long originAmount, Long afterAmount) {
+        dailyBudget.addSpent(afterAmount - originAmount);
+        monthlyBudget.addSpent(afterAmount - originAmount);
+        this.amount = afterAmount;
+    }
+
+    private void updateTradeName(String tradeName) {
+        this.tradeName = tradeName;
+    }
+
+    public void edit(LocalDateTime spentDate, Long amount, String tradeName) {
+        updateSpentDate(spentDate);
+        updateAmount(this.amount, amount);
+        updateTradeName(tradeName);
+    }
+}

--- a/src/main/java/com/stcom/smartmealtable/domain/Budget/Expenditure.java
+++ b/src/main/java/com/stcom/smartmealtable/domain/Budget/Expenditure.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -55,8 +56,9 @@ public class Expenditure extends BaseTimeEntity {
     }
 
     private void updateAmount(Long originAmount, Long afterAmount) {
-        dailyBudget.addSpent(afterAmount - originAmount);
-        monthlyBudget.addSpent(afterAmount - originAmount);
+        Long difference = afterAmount - originAmount;
+        dailyBudget.addSpent(BigDecimal.valueOf(difference));
+        monthlyBudget.addSpent(BigDecimal.valueOf(difference));
         this.amount = afterAmount;
     }
 

--- a/src/main/java/com/stcom/smartmealtable/domain/Budget/MonthlyBudget.java
+++ b/src/main/java/com/stcom/smartmealtable/domain/Budget/MonthlyBudget.java
@@ -24,4 +24,5 @@ public class MonthlyBudget extends Budget {
     @Convert(converter = YearMonthConverter.class)
     @Column(name = "budget_year_month")
     private YearMonth yearMonth;
+    
 }

--- a/src/main/java/com/stcom/smartmealtable/repository/ExpenditureRepository.java
+++ b/src/main/java/com/stcom/smartmealtable/repository/ExpenditureRepository.java
@@ -1,0 +1,14 @@
+package com.stcom.smartmealtable.repository;
+
+import com.stcom.smartmealtable.domain.Budget.Expenditure;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExpenditureRepository extends JpaRepository<Expenditure, Long> {
+
+    Slice<Expenditure> findByDailyBudget_MemberProfile_IdOrderBySpentDateDesc(Long profileId, Pageable pageable);
+
+    List<Expenditure> findExpendituresById(Long id);
+}

--- a/src/main/java/com/stcom/smartmealtable/repository/ExpenditureRepository.java
+++ b/src/main/java/com/stcom/smartmealtable/repository/ExpenditureRepository.java
@@ -1,7 +1,6 @@
 package com.stcom.smartmealtable.repository;
 
 import com.stcom.smartmealtable.domain.Budget.Expenditure;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +8,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ExpenditureRepository extends JpaRepository<Expenditure, Long> {
 
     Slice<Expenditure> findByDailyBudget_MemberProfile_IdOrderBySpentDateDesc(Long profileId, Pageable pageable);
-
-    List<Expenditure> findExpendituresById(Long id);
 }

--- a/src/main/java/com/stcom/smartmealtable/service/ExpenditureService.java
+++ b/src/main/java/com/stcom/smartmealtable/service/ExpenditureService.java
@@ -1,0 +1,84 @@
+package com.stcom.smartmealtable.service;
+
+import com.stcom.smartmealtable.domain.Budget.DailyBudget;
+import com.stcom.smartmealtable.domain.Budget.Expenditure;
+import com.stcom.smartmealtable.domain.Budget.MonthlyBudget;
+import com.stcom.smartmealtable.repository.BudgetRepository;
+import com.stcom.smartmealtable.repository.ExpenditureRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExpenditureService {
+
+    private final ExpenditureRepository expenditureRepository;
+    private final BudgetRepository budgetRepository;
+
+    @Transactional
+    public void registerExpenditure(Long profileId,
+                                    LocalDateTime spentDate,
+                                    Long amount,
+                                    String tradeName) {
+
+        LocalDate date = spentDate.toLocalDate();
+        YearMonth yearMonth = YearMonth.from(spentDate);
+
+        DailyBudget dailyBudget = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(profileId, date)
+                .orElseThrow(() -> new IllegalArgumentException("일일 예산이 존재하지 않습니다."));
+        MonthlyBudget monthlyBudget = budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(profileId,
+                        yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("월별 예산이 존재하지 않습니다."));
+
+        Expenditure expenditure = Expenditure.builder()
+                .spentDate(spentDate)
+                .amount(amount)
+                .tradeName(tradeName)
+                .dailyBudget(dailyBudget)
+                .monthlyBudget(monthlyBudget)
+                .build();
+        expenditureRepository.save(expenditure);
+
+        BigDecimal spent = BigDecimal.valueOf(amount);
+        dailyBudget.addSpent(spent);
+        monthlyBudget.addSpent(spent);
+    }
+
+    public Slice<Expenditure> getExpenditures(Long profileId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "spentDate"));
+        return expenditureRepository.findByDailyBudget_MemberProfile_IdOrderBySpentDateDesc(profileId, pageable);
+    }
+
+    @Transactional
+    public void editExpenditure(Long profileId, Long expenditureId, LocalDateTime spentDate, Long amount,
+                                String tradeName) {
+        Expenditure expenditure = expenditureRepository.findById(expenditureId)
+                .orElseThrow(() -> new IllegalArgumentException("지출 내역이 존재하지 않습니다."));
+        expenditure.edit(spentDate, amount, tradeName);
+    }
+
+    @Transactional
+    public void deleteExpenditure(Long profileId, Long expenditureId) {
+        Expenditure expenditure = expenditureRepository.findById(expenditureId)
+                .orElseThrow(() -> new IllegalArgumentException("지출 내역이 존재하지 않습니다."));
+
+        DailyBudget dailyBudget = expenditure.getDailyBudget();
+        MonthlyBudget monthlyBudget = expenditure.getMonthlyBudget();
+
+        BigDecimal spent = BigDecimal.valueOf(expenditure.getAmount());
+        dailyBudget.subtractSpent(spent);
+        monthlyBudget.subtractSpent(spent);
+
+        expenditureRepository.delete(expenditure);
+    }
+}

--- a/src/main/java/com/stcom/smartmealtable/service/ExpenditureService.java
+++ b/src/main/java/com/stcom/smartmealtable/service/ExpenditureService.java
@@ -64,6 +64,11 @@ public class ExpenditureService {
                                 String tradeName) {
         Expenditure expenditure = expenditureRepository.findById(expenditureId)
                 .orElseThrow(() -> new IllegalArgumentException("지출 내역이 존재하지 않습니다."));
+
+        if (!expenditure.getDailyBudget().getMemberProfile().getId().equals(profileId)) {
+            throw new IllegalArgumentException("해당 지출 내역 등록자와 접근자가 다릅니다.");
+        }
+        
         expenditure.edit(spentDate, amount, tradeName);
     }
 
@@ -74,6 +79,10 @@ public class ExpenditureService {
 
         DailyBudget dailyBudget = expenditure.getDailyBudget();
         MonthlyBudget monthlyBudget = expenditure.getMonthlyBudget();
+
+        if (!dailyBudget.getMemberProfile().getId().equals(profileId)) {
+            throw new IllegalArgumentException("해당 지출 내역 등록자와 접근자가 다릅니다.");
+        }
 
         BigDecimal spent = BigDecimal.valueOf(expenditure.getAmount());
         dailyBudget.subtractSpent(spent);

--- a/src/main/java/com/stcom/smartmealtable/web/controller/MemberExpenditureController.java
+++ b/src/main/java/com/stcom/smartmealtable/web/controller/MemberExpenditureController.java
@@ -8,6 +8,8 @@ import com.stcom.smartmealtable.service.dto.MemberDto;
 import com.stcom.smartmealtable.web.argumentresolver.UserContext;
 import com.stcom.smartmealtable.web.dto.ApiResponse;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -16,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -35,7 +38,7 @@ public class MemberExpenditureController {
     private final ExpenditureService expenditureService;
     private final CreditMessageManager creditMessageManager;
 
-    @GetMapping("/messages/parse")
+    @PostMapping("/messages/parse")
     public ApiResponse<ExpenditureDto> parseCreditMessage(@RequestBody ParseRequest request) {
         return ApiResponse.createSuccess(creditMessageManager.parseMessage(request.getMessage()));
     }
@@ -51,7 +54,7 @@ public class MemberExpenditureController {
 
     @PostMapping
     public ApiResponse<Void> registerExpenditure(@UserContext MemberDto memberDto,
-                                                 @RequestBody ExpenditureRequest request) {
+                                                 @RequestBody @Validated ExpenditureRequest request) {
         expenditureService.registerExpenditure(
                 memberDto.getProfileId(),
                 request.getSpentDate(),
@@ -63,7 +66,7 @@ public class MemberExpenditureController {
 
     @PatchMapping("/{id}")
     public ApiResponse<Void> editExpenditure(@UserContext MemberDto memberDto, @PathVariable("id") Long expenditureId,
-                                             @RequestBody ExpenditureRequest request) {
+                                             @RequestBody @Validated ExpenditureRequest request) {
         expenditureService.editExpenditure(
                 memberDto.getProfileId(),
                 expenditureId,
@@ -91,9 +94,16 @@ public class MemberExpenditureController {
 
     @Data
     static class ExpenditureRequest {
+
         @DateTimeFormat(iso = ISO.DATE_TIME)
+        @NotNull
         private LocalDateTime spentDate;
+
+        @NotNull
+        @Positive
         private Long amount;
+
+        @NotEmpty
         private String tradeName;
     }
 

--- a/src/main/java/com/stcom/smartmealtable/web/controller/MemberExpenditureController.java
+++ b/src/main/java/com/stcom/smartmealtable/web/controller/MemberExpenditureController.java
@@ -1,0 +1,114 @@
+package com.stcom.smartmealtable.web.controller;
+
+import com.stcom.smartmealtable.component.creditmessage.CreditMessageManager;
+import com.stcom.smartmealtable.component.creditmessage.ExpenditureDto;
+import com.stcom.smartmealtable.domain.Budget.Expenditure;
+import com.stcom.smartmealtable.service.ExpenditureService;
+import com.stcom.smartmealtable.service.dto.MemberDto;
+import com.stcom.smartmealtable.web.argumentresolver.UserContext;
+import com.stcom.smartmealtable.web.dto.ApiResponse;
+import jakarta.validation.constraints.NotEmpty;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1/members/me/expenditures")
+public class MemberExpenditureController {
+
+    private final ExpenditureService expenditureService;
+    private final CreditMessageManager creditMessageManager;
+
+    @GetMapping("/messages/parse")
+    public ApiResponse<ExpenditureDto> parseCreditMessage(@RequestBody ParseRequest request) {
+        return ApiResponse.createSuccess(creditMessageManager.parseMessage(request.getMessage()));
+    }
+
+    @GetMapping
+    public ApiResponse<Slice<ExpenditureResponse>> getExpenditures(@UserContext MemberDto memberDto,
+                                                                   @RequestParam(name = "page", defaultValue = "0") int page,
+                                                                   @RequestParam(name = "size", defaultValue = "10") int size) {
+        Slice<Expenditure> slice = expenditureService.getExpenditures(memberDto.getProfileId(), page, size);
+        Slice<ExpenditureResponse> responseSlice = slice.map(ExpenditureResponse::of);
+        return ApiResponse.createSuccess(responseSlice);
+    }
+
+    @PostMapping
+    public ApiResponse<Void> registerExpenditure(@UserContext MemberDto memberDto,
+                                                 @RequestBody ExpenditureRequest request) {
+        expenditureService.registerExpenditure(
+                memberDto.getProfileId(),
+                request.getSpentDate(),
+                request.getAmount(),
+                request.getTradeName()
+        );
+        return ApiResponse.createSuccessWithNoContent();
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<Void> editExpenditure(@UserContext MemberDto memberDto, @PathVariable("id") Long expenditureId,
+                                             @RequestBody ExpenditureRequest request) {
+        expenditureService.editExpenditure(
+                memberDto.getProfileId(),
+                expenditureId,
+                request.getSpentDate(),
+                request.getAmount(),
+                request.getTradeName()
+        );
+        return ApiResponse.createSuccessWithNoContent();
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteExpenditure(@UserContext MemberDto memberDto,
+                                               @PathVariable("id") Long expenditureId) {
+        expenditureService.deleteExpenditure(memberDto.getProfileId(), expenditureId);
+        return ApiResponse.createSuccessWithNoContent();
+    }
+
+    @Data
+    static class ParseRequest {
+
+        @NotEmpty
+        private String message;
+
+    }
+
+    @Data
+    static class ExpenditureRequest {
+        @DateTimeFormat(iso = ISO.DATE_TIME)
+        private LocalDateTime spentDate;
+        private Long amount;
+        private String tradeName;
+    }
+
+    @Data
+    @AllArgsConstructor
+    static class ExpenditureResponse {
+
+        private Long id;
+        private LocalDateTime spentDate;
+        private Long amount;
+        private String tradeName;
+
+        public static ExpenditureResponse of(Expenditure expenditure) {
+            return new ExpenditureResponse(expenditure.getId(), expenditure.getSpentDate(), expenditure.getAmount(),
+                    expenditure.getTradeName());
+        }
+    }
+}

--- a/src/test/java/com/stcom/smartmealtable/component/creditmessage/GeminiCreditMessageParserTest.java
+++ b/src/test/java/com/stcom/smartmealtable/component/creditmessage/GeminiCreditMessageParserTest.java
@@ -49,7 +49,7 @@ class GeminiCreditMessageParserTest {
                 () -> assertEquals("KB", dto.getVendor()),
                 () -> assertEquals(11000L, dto.getAmount()),
                 () -> assertEquals("스타벅스", dto.getTradeName()),
-                () -> assertEquals("2025-06-12T10:20", dto.getDateTime().toString().substring(0, 16))
+                () -> assertEquals("2025-06-12T10:20", dto.getSpentDate().toString().substring(0, 16))
         );
     }
 }

--- a/src/test/java/com/stcom/smartmealtable/component/creditmessage/KBCreditMessageParserTest.java
+++ b/src/test/java/com/stcom/smartmealtable/component/creditmessage/KBCreditMessageParserTest.java
@@ -38,7 +38,8 @@ class KBCreditMessageParserTest {
         ExpenditureDto expenditure = parser.parse(kbMessage);
         // then
         assertThat(expenditure.getVendor()).isEqualTo("KB");
-        assertThat(expenditure.getDateTime()).isEqualTo(LocalDateTime.of(LocalDateTime.now().getYear(), 7, 16, 12, 28));
+        assertThat(expenditure.getSpentDate()).isEqualTo(
+                LocalDateTime.of(LocalDateTime.now().getYear(), 7, 16, 12, 28));
         assertThat(expenditure.getAmount()).isEqualTo(11000);
         assertThat(expenditure.getTradeName()).isEqualTo("롯데시네마 평촌");
 

--- a/src/test/java/com/stcom/smartmealtable/component/creditmessage/NHCreditMessageParserTest.java
+++ b/src/test/java/com/stcom/smartmealtable/component/creditmessage/NHCreditMessageParserTest.java
@@ -38,7 +38,8 @@ class NHCreditMessageParserTest {
         ExpenditureDto expenditure = parser.parse(nhMessage);
         // then
         assertThat(expenditure.getVendor()).isEqualTo("NH");
-        assertThat(expenditure.getDateTime()).isEqualTo(LocalDateTime.of(LocalDateTime.now().getYear(), 10, 21, 8, 33));
+        assertThat(expenditure.getSpentDate()).isEqualTo(
+                LocalDateTime.of(LocalDateTime.now().getYear(), 10, 21, 8, 33));
         assertThat(expenditure.getAmount()).isEqualTo(5700);
         assertThat(expenditure.getTradeName()).isEqualTo("(주)티머니 개인택");
 

--- a/src/test/java/com/stcom/smartmealtable/component/creditmessage/SHCreditMessageParserTest.java
+++ b/src/test/java/com/stcom/smartmealtable/component/creditmessage/SHCreditMessageParserTest.java
@@ -38,7 +38,8 @@ class SHCreditMessageParserTest {
         ExpenditureDto expenditure = parser.parse(shMessage);
         // then
         assertThat(expenditure.getVendor()).isEqualTo("SH");
-        assertThat(expenditure.getDateTime()).isEqualTo(LocalDateTime.of(LocalDateTime.now().getYear(), 10, 21, 8, 33));
+        assertThat(expenditure.getSpentDate()).isEqualTo(
+                LocalDateTime.of(LocalDateTime.now().getYear(), 10, 21, 8, 33));
         assertThat(expenditure.getAmount()).isEqualTo(5700);
         assertThat(expenditure.getTradeName()).isEqualTo("(주)티머니 개인택");
 

--- a/src/test/java/com/stcom/smartmealtable/domain/Budget/ExpenditureTest.java
+++ b/src/test/java/com/stcom/smartmealtable/domain/Budget/ExpenditureTest.java
@@ -1,0 +1,202 @@
+package com.stcom.smartmealtable.domain.Budget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.stcom.smartmealtable.domain.member.MemberProfile;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ExpenditureTest {
+
+    private MemberProfile memberProfile;
+    private DailyBudget dailyBudget;
+    private MonthlyBudget monthlyBudget;
+
+    @BeforeEach
+    void setUp() {
+        memberProfile = new MemberProfile();
+        LocalDate today = LocalDate.now();
+        YearMonth thisMonth = YearMonth.from(today);
+        
+        dailyBudget = new DailyBudget(memberProfile, BigDecimal.valueOf(50_000), today);
+        monthlyBudget = new MonthlyBudget(memberProfile, BigDecimal.valueOf(1_000_000), thisMonth);
+    }
+
+    @Test
+    @DisplayName("Expenditure 객체가 정상적으로 생성된다")
+    void createExpenditure() {
+        // given
+        LocalDateTime spentDate = LocalDateTime.now();
+        Long amount = 12000L;
+        String tradeName = "Lunch";
+
+        // when
+        Expenditure expenditure = Expenditure.builder()
+                .spentDate(spentDate)
+                .amount(amount)
+                .tradeName(tradeName)
+                .dailyBudget(dailyBudget)
+                .monthlyBudget(monthlyBudget)
+                .build();
+
+        // then
+        assertThat(expenditure.getSpentDate()).isEqualTo(spentDate);
+        assertThat(expenditure.getAmount()).isEqualTo(amount);
+        assertThat(expenditure.getTradeName()).isEqualTo(tradeName);
+        assertThat(expenditure.getDailyBudget()).isEqualTo(dailyBudget);
+        assertThat(expenditure.getMonthlyBudget()).isEqualTo(monthlyBudget);
+    }
+
+    @Test
+    @DisplayName("지출 내역 수정 시 예산에 차액이 반영된다")
+    void editExpenditure_AmountChanged() {
+        // given
+        LocalDateTime originalSpentDate = LocalDateTime.now();
+        Long originalAmount = 12000L;
+        String originalTradeName = "Lunch";
+        
+        Expenditure expenditure = Expenditure.builder()
+                .spentDate(originalSpentDate)
+                .amount(originalAmount)
+                .tradeName(originalTradeName)
+                .dailyBudget(dailyBudget)
+                .monthlyBudget(monthlyBudget)
+                .build();
+        
+        // 초기 예산에 지출 추가
+        dailyBudget.addSpent(BigDecimal.valueOf(originalAmount));
+        monthlyBudget.addSpent(BigDecimal.valueOf(originalAmount));
+        
+        LocalDateTime newSpentDate = LocalDateTime.now().plusHours(1);
+        Long newAmount = 15000L; // 3000원 증가
+        String newTradeName = "Dinner";
+
+        // when
+        expenditure.edit(newSpentDate, newAmount, newTradeName);
+
+        // then
+        assertThat(expenditure.getSpentDate()).isEqualTo(newSpentDate);
+        assertThat(expenditure.getAmount()).isEqualTo(newAmount);
+        assertThat(expenditure.getTradeName()).isEqualTo(newTradeName);
+        
+        // 예산에 차액(3000원)이 추가로 반영되어야 함
+        assertThat(dailyBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(15000));
+        assertThat(monthlyBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(15000));
+    }
+
+    @Test
+    @DisplayName("지출 금액을 줄여서 수정하면 예산에서 차액만큼 차감된다")
+    void editExpenditure_AmountDecreased() {
+        // given
+        LocalDateTime originalSpentDate = LocalDateTime.now();
+        Long originalAmount = 15000L;
+        String originalTradeName = "Dinner";
+        
+        Expenditure expenditure = Expenditure.builder()
+                .spentDate(originalSpentDate)
+                .amount(originalAmount)
+                .tradeName(originalTradeName)
+                .dailyBudget(dailyBudget)
+                .monthlyBudget(monthlyBudget)
+                .build();
+        
+        // 초기 예산에 지출 추가
+        dailyBudget.addSpent(BigDecimal.valueOf(originalAmount));
+        monthlyBudget.addSpent(BigDecimal.valueOf(originalAmount));
+        
+        LocalDateTime newSpentDate = LocalDateTime.now().plusHours(1);
+        Long newAmount = 10000L; // 5000원 감소
+        String newTradeName = "Lunch";
+
+        // when
+        expenditure.edit(newSpentDate, newAmount, newTradeName);
+
+        // then
+        assertThat(expenditure.getAmount()).isEqualTo(newAmount);
+        
+        // 예산에서 차액(5000원)이 차감되어야 함
+        assertThat(dailyBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(10000));
+        assertThat(monthlyBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(10000));
+    }
+
+    @Test
+    @DisplayName("지출 금액을 동일하게 수정해도 예산에 변화가 없다")
+    void editExpenditure_SameAmount() {
+        // given
+        LocalDateTime originalSpentDate = LocalDateTime.now();
+        Long originalAmount = 12000L;
+        String originalTradeName = "Lunch";
+        
+        Expenditure expenditure = Expenditure.builder()
+                .spentDate(originalSpentDate)
+                .amount(originalAmount)
+                .tradeName(originalTradeName)
+                .dailyBudget(dailyBudget)
+                .monthlyBudget(monthlyBudget)
+                .build();
+        
+        // 초기 예산에 지출 추가
+        dailyBudget.addSpent(BigDecimal.valueOf(originalAmount));
+        monthlyBudget.addSpent(BigDecimal.valueOf(originalAmount));
+        
+        LocalDateTime newSpentDate = LocalDateTime.now().plusHours(1);
+        Long newAmount = 12000L; // 동일한 금액
+        String newTradeName = "Brunch";
+
+        // when
+        expenditure.edit(newSpentDate, newAmount, newTradeName);
+
+        // then
+        assertThat(expenditure.getSpentDate()).isEqualTo(newSpentDate);
+        assertThat(expenditure.getAmount()).isEqualTo(newAmount);
+        assertThat(expenditure.getTradeName()).isEqualTo(newTradeName);
+        
+        // 예산에 변화가 없어야 함
+        assertThat(dailyBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(originalAmount));
+        assertThat(monthlyBudget.getSpendAmount()).isEqualTo(BigDecimal.valueOf(originalAmount));
+    }
+
+    @Test
+    @DisplayName("지출 날짜와 상호명만 수정하고 금액은 그대로 두면 예산에 변화가 없다")
+    void editExpenditure_OnlyDateAndTradeName() {
+        // given
+        LocalDateTime originalSpentDate = LocalDateTime.now();
+        Long amount = 12000L;
+        String originalTradeName = "Lunch";
+        
+        Expenditure expenditure = Expenditure.builder()
+                .spentDate(originalSpentDate)
+                .amount(amount)
+                .tradeName(originalTradeName)
+                .dailyBudget(dailyBudget)
+                .monthlyBudget(monthlyBudget)
+                .build();
+        
+        // 초기 예산에 지출 추가
+        dailyBudget.addSpent(BigDecimal.valueOf(amount));
+        monthlyBudget.addSpent(BigDecimal.valueOf(amount));
+        
+        BigDecimal originalDailySpent = dailyBudget.getSpendAmount();
+        BigDecimal originalMonthlySpent = monthlyBudget.getSpendAmount();
+        
+        LocalDateTime newSpentDate = LocalDateTime.now().plusHours(2);
+        String newTradeName = "Late Lunch";
+
+        // when
+        expenditure.edit(newSpentDate, amount, newTradeName);
+
+        // then
+        assertThat(expenditure.getSpentDate()).isEqualTo(newSpentDate);
+        assertThat(expenditure.getAmount()).isEqualTo(amount);
+        assertThat(expenditure.getTradeName()).isEqualTo(newTradeName);
+        
+        // 예산에 변화가 없어야 함
+        assertThat(dailyBudget.getSpendAmount()).isEqualTo(originalDailySpent);
+        assertThat(monthlyBudget.getSpendAmount()).isEqualTo(originalMonthlySpent);
+    }
+} 

--- a/src/test/java/com/stcom/smartmealtable/repository/ExpenditureRepositoryTest.java
+++ b/src/test/java/com/stcom/smartmealtable/repository/ExpenditureRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.stcom.smartmealtable.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.stcom.smartmealtable.domain.Budget.DailyBudget;
+import com.stcom.smartmealtable.domain.Budget.Expenditure;
+import com.stcom.smartmealtable.domain.Budget.MonthlyBudget;
+import com.stcom.smartmealtable.domain.member.Member;
+import com.stcom.smartmealtable.domain.member.MemberProfile;
+import com.stcom.smartmealtable.domain.member.MemberType;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+import com.stcom.smartmealtable.repository.MemberRepository;
+import com.stcom.smartmealtable.repository.MemberProfileRepository;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ExpenditureRepositoryTest {
+
+    @Autowired
+    private ExpenditureRepository expenditureRepository;
+
+    @Autowired
+    private BudgetRepository budgetRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MemberProfileRepository memberProfileRepository;
+
+    @DisplayName("Slice 기반 무한스크롤 조회가 최신순으로 올바르게 동작한다")
+    @Test
+    void slicePaginationByProfile() {
+        // given
+        Member member = Member.builder()
+                .email("slice@test.com")
+                .rawPassword("@Password1")
+                .build();
+        memberRepository.save(member);
+
+        MemberProfile profile = MemberProfile.builder()
+                .member(member)
+                .nickName("tester")
+                .type(MemberType.OTHER)
+                .build();
+        memberProfileRepository.save(profile);
+
+        LocalDate today = LocalDate.now();
+        YearMonth thisMonth = YearMonth.now();
+
+        DailyBudget dailyBudget = new DailyBudget(profile, BigDecimal.valueOf(10_000), today);
+        MonthlyBudget monthlyBudget = new MonthlyBudget(profile, BigDecimal.valueOf(300_000), thisMonth);
+        budgetRepository.save(dailyBudget);
+        budgetRepository.save(monthlyBudget);
+
+        // 15개의 지출내역 생성 (1분 간격으로 시간 차이)
+        IntStream.range(0, 15).forEach(i -> {
+            LocalDateTime spentDate = LocalDateTime.now().minusMinutes(i);
+            Expenditure expenditure = Expenditure.builder()
+                    .spentDate(spentDate)
+                    .amount(1000L + i)
+                    .tradeName("coffee" + i)
+                    .dailyBudget(dailyBudget)
+                    .monthlyBudget(monthlyBudget)
+                    .build();
+            expenditureRepository.save(expenditure);
+        });
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "spentDate"));
+
+        // when
+        Slice<Expenditure> slice = expenditureRepository
+                .findByDailyBudget_MemberProfile_IdOrderBySpentDateDesc(profile.getId(), pageable);
+
+        // then
+        assertThat(slice).isNotNull();
+        assertThat(slice.getContent()).hasSize(10);
+        assertThat(slice.hasNext()).isTrue();
+
+        // spentDate 가 내림차순인지 확인
+        boolean sortedDesc = slice.getContent().stream()
+                .sorted(Comparator.comparing(Expenditure::getSpentDate).reversed())
+                .toList()
+                .equals(slice.getContent());
+        assertThat(sortedDesc).isTrue();
+    }
+}

--- a/src/test/java/com/stcom/smartmealtable/service/ExpenditureServiceIntegrationTest.java
+++ b/src/test/java/com/stcom/smartmealtable/service/ExpenditureServiceIntegrationTest.java
@@ -1,0 +1,208 @@
+package com.stcom.smartmealtable.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.stcom.smartmealtable.domain.Budget.DailyBudget;
+import com.stcom.smartmealtable.domain.Budget.Expenditure;
+import com.stcom.smartmealtable.domain.Budget.MonthlyBudget;
+import com.stcom.smartmealtable.domain.member.Member;
+import com.stcom.smartmealtable.domain.member.MemberProfile;
+import com.stcom.smartmealtable.repository.BudgetRepository;
+import com.stcom.smartmealtable.repository.ExpenditureRepository;
+import com.stcom.smartmealtable.repository.MemberProfileRepository;
+import com.stcom.smartmealtable.repository.MemberRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(ExpenditureService.class)
+class ExpenditureServiceIntegrationTest {
+
+    @Autowired
+    private ExpenditureService expenditureService;
+    @Autowired
+    private ExpenditureRepository expenditureRepository;
+    @Autowired
+    private BudgetRepository budgetRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MemberProfileRepository memberProfileRepository;
+
+    private Member member;
+    private MemberProfile profile;
+    private DailyBudget dailyBudget;
+    private MonthlyBudget monthlyBudget;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .email("exptest@example.com")
+                .rawPassword("P@ssw0rd!")
+                .build();
+        memberRepository.save(member);
+
+        profile = MemberProfile.builder()
+                .member(member)
+                .nickName("tester")
+                .build();
+        memberProfileRepository.save(profile);
+
+        LocalDate today = LocalDate.now();
+        YearMonth thisMonth = YearMonth.from(today);
+
+        dailyBudget = new DailyBudget(profile, BigDecimal.valueOf(50_000), today);
+        monthlyBudget = new MonthlyBudget(profile, BigDecimal.valueOf(1_000_000), thisMonth);
+        budgetRepository.save(dailyBudget);
+        budgetRepository.save(monthlyBudget);
+    }
+
+    @DisplayName("지출 등록 시 Expenditure 저장 및 해당 예산 사용금액이 증가한다")
+    @Test
+    void registerExpenditure() {
+        // given
+        LocalDateTime spentDate = LocalDateTime.now();
+        Long amount = 12000L;
+        String tradeName = "Lunch";
+
+        // when
+        expenditureService.registerExpenditure(profile.getId(), spentDate, amount, tradeName);
+
+        // then
+        Expenditure saved = expenditureRepository.findAll().getFirst();
+        assertThat(saved).isNotNull();
+        assertThat(saved.getTradeName()).isEqualTo(tradeName);
+        assertThat(saved.getAmount()).isEqualTo(amount);
+        assertThat(saved.getDailyBudget().getId()).isEqualTo(dailyBudget.getId());
+        assertThat(saved.getMonthlyBudget().getId()).isEqualTo(monthlyBudget.getId());
+
+        DailyBudget reloadedDaily = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(profile.getId(),
+                dailyBudget.getDate()).orElseThrow();
+        MonthlyBudget reloadedMonthly = budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(profile.getId(),
+                monthlyBudget.getYearMonth()).orElseThrow();
+
+        assertThat(reloadedDaily.getSpendAmount()).isEqualTo(BigDecimal.valueOf(amount));
+        assertThat(reloadedMonthly.getSpendAmount()).isEqualTo(BigDecimal.valueOf(amount));
+    }
+
+    @DisplayName("지출 내역을 페이징으로 조회할 수 있다")
+    @Test
+    void getExpenditures() {
+        // given
+        LocalDateTime spentDate1 = LocalDateTime.now().withHour(9).withMinute(0);
+        LocalDateTime spentDate2 = LocalDateTime.now().withHour(12).withMinute(0);
+        LocalDateTime spentDate3 = LocalDateTime.now().withHour(18).withMinute(0);
+        
+        expenditureService.registerExpenditure(profile.getId(), spentDate1, 10000L, "Breakfast");
+        expenditureService.registerExpenditure(profile.getId(), spentDate2, 15000L, "Lunch");
+        expenditureService.registerExpenditure(profile.getId(), spentDate3, 20000L, "Dinner");
+
+        // when
+        var result = expenditureService.getExpenditures(profile.getId(), 0, 2);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getTradeName()).isEqualTo("Dinner"); // 최신순
+        assertThat(result.getContent().get(1).getTradeName()).isEqualTo("Lunch");
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    @DisplayName("지출 내역을 수정할 수 있다")
+    @Test
+    void editExpenditure() {
+        // given
+        LocalDateTime originalSpentDate = LocalDateTime.now();
+        Long originalAmount = 12000L;
+        String originalTradeName = "Lunch";
+        
+        expenditureService.registerExpenditure(profile.getId(), originalSpentDate, originalAmount, originalTradeName);
+        Expenditure savedExpenditure = expenditureRepository.findAll().getFirst();
+        
+        LocalDateTime newSpentDate = LocalDateTime.now().plusHours(1);
+        Long newAmount = 15000L;
+        String newTradeName = "Dinner";
+
+        // when
+        expenditureService.editExpenditure(profile.getId(), savedExpenditure.getId(), newSpentDate, newAmount, newTradeName);
+
+        // then
+        Expenditure updatedExpenditure = expenditureRepository.findById(savedExpenditure.getId()).orElseThrow();
+        assertThat(updatedExpenditure.getSpentDate()).isEqualTo(newSpentDate);
+        assertThat(updatedExpenditure.getAmount()).isEqualTo(newAmount);
+        assertThat(updatedExpenditure.getTradeName()).isEqualTo(newTradeName);
+    }
+
+    @DisplayName("지출 내역을 삭제하면 예산에서 해당 금액이 차감된다")
+    @Test
+    void deleteExpenditure() {
+        // given
+        LocalDateTime spentDate = LocalDateTime.now();
+        Long amount = 12000L;
+        String tradeName = "Lunch";
+        
+        expenditureService.registerExpenditure(profile.getId(), spentDate, amount, tradeName);
+        Expenditure savedExpenditure = expenditureRepository.findAll().getFirst();
+        
+        // 삭제 전 예산 확인
+        DailyBudget beforeDeleteDaily = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(profile.getId(),
+                dailyBudget.getDate()).orElseThrow();
+        MonthlyBudget beforeDeleteMonthly = budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(profile.getId(),
+                monthlyBudget.getYearMonth()).orElseThrow();
+        
+        assertThat(beforeDeleteDaily.getSpendAmount()).isEqualTo(BigDecimal.valueOf(amount));
+        assertThat(beforeDeleteMonthly.getSpendAmount()).isEqualTo(BigDecimal.valueOf(amount));
+
+        // when
+        expenditureService.deleteExpenditure(profile.getId(), savedExpenditure.getId());
+
+        // then
+        assertThat(expenditureRepository.findById(savedExpenditure.getId())).isEmpty();
+        
+        DailyBudget afterDeleteDaily = budgetRepository.findDailyBudgetByMemberProfileIdAndDate(profile.getId(),
+                dailyBudget.getDate()).orElseThrow();
+        MonthlyBudget afterDeleteMonthly = budgetRepository.findMonthlyBudgetByMemberProfileIdAndYearMonth(profile.getId(),
+                monthlyBudget.getYearMonth()).orElseThrow();
+        
+        assertThat(afterDeleteDaily.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+        assertThat(afterDeleteMonthly.getSpendAmount()).isEqualTo(BigDecimal.ZERO);
+    }
+
+    @DisplayName("존재하지 않는 지출 내역 수정 시 예외가 발생한다")
+    @Test
+    void editExpenditure_NotFound() {
+        // given
+        Long nonExistentExpenditureId = 999L;
+        LocalDateTime spentDate = LocalDateTime.now();
+        Long amount = 12000L;
+        String tradeName = "Lunch";
+
+        // when & then
+        assertThatThrownBy(() -> expenditureService.editExpenditure(profile.getId(), nonExistentExpenditureId, spentDate, amount, tradeName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("지출 내역이 존재하지 않습니다.");
+    }
+
+    @DisplayName("존재하지 않는 지출 내역 삭제 시 예외가 발생한다")
+    @Test
+    void deleteExpenditure_NotFound() {
+        // given
+        Long nonExistentExpenditureId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> expenditureService.deleteExpenditure(profile.getId(), nonExistentExpenditureId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("지출 내역이 존재하지 않습니다.");
+    }
+
+} 


### PR DESCRIPTION
1. 무한 스크롤 페이징 지출 내역 조회 API
2. 결제 메시지 파싱 API
3. 지출 내역 등록 API
4. 지출 내역 수정 API
5. 지출 내역 삭제 API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - 사용자의 지출 내역을 등록, 조회(페이지네이션 지원), 수정, 삭제할 수 있는 API가 추가되었습니다.
    - 신용카드 문자 메시지를 지출 정보로 변환하는 기능이 추가되었습니다.
- **Bug Fixes**
    - 일부 화면에서 지출 일자 필드명이 일관성 있게 변경되었습니다.
- **Tests**
    - 지출 및 예산 관리 기능에 대한 단위 테스트와 통합 테스트가 추가되어 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->